### PR TITLE
Implement `CanonicalSerialize` and `CanonicalDeserialize` for signed integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Features
 
+- (`ark-serialize`) Implementation of `CanonicalSerialize` and `CanonicalDeserialize` for signed integer types
+
 ### Improvements
 
 ### Bugfixes

--- a/serialize/src/impls.rs
+++ b/serialize/src/impls.rs
@@ -103,6 +103,10 @@ impl_uint!(u8);
 impl_uint!(u16);
 impl_uint!(u32);
 impl_uint!(u64);
+impl_uint!(i8);
+impl_uint!(i16);
+impl_uint!(i32);
+impl_uint!(i64);
 
 impl CanonicalSerialize for usize {
     #[inline]
@@ -145,6 +149,50 @@ impl CanonicalDeserialize for usize {
         let mut bytes = [0u8; core::mem::size_of::<u64>()];
         reader.read_exact(&mut bytes)?;
         Ok(<u64>::from_le_bytes(bytes) as usize)
+    }
+}
+
+impl CanonicalSerialize for isize {
+    #[inline]
+    fn serialize_with_mode<W: Write>(
+        &self,
+        mut writer: W,
+        _compress: Compress,
+    ) -> Result<(), SerializationError> {
+        Ok(writer.write_all(&(*self as i64).to_le_bytes())?)
+    }
+
+    #[inline]
+    fn serialized_size(&self, _compress: Compress) -> usize {
+        core::mem::size_of::<i64>()
+    }
+}
+
+impl Valid for isize {
+    #[inline]
+    fn check(&self) -> Result<(), SerializationError> {
+        Ok(())
+    }
+
+    #[inline]
+    fn batch_check<'a>(_batch: impl Iterator<Item = &'a Self>) -> Result<(), SerializationError>
+    where
+        Self: 'a,
+    {
+        Ok(())
+    }
+}
+
+impl CanonicalDeserialize for isize {
+    #[inline]
+    fn deserialize_with_mode<R: Read>(
+        mut reader: R,
+        _compress: Compress,
+        _validate: Validate,
+    ) -> Result<Self, SerializationError> {
+        let mut bytes = [0u8; core::mem::size_of::<i64>()];
+        reader.read_exact(&mut bytes)?;
+        Ok(<i64>::from_le_bytes(bytes) as Self)
     }
 }
 


### PR DESCRIPTION
## Description

This PR adds `CanonicalSerialize` and `CanonicalDeserialize` for signed integers for use in https://github.com/a16z/jolt/pull/616