### PR TITLE
[do not merge] Optimized mul_u64 for v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Features
 
+- (`ark-serialize`) Implementation of `CanonicalSerialize` and `CanonicalDeserialize` for signed integer types
+
+- (`montgomery_backend.rs`) Implementation of optimized multiplication by u64, using specialized Barrett reduction
+
 ### Improvements
 
 ### Bugfixes

--- a/bench-templates/src/macros/field.rs
+++ b/bench-templates/src/macros/field.rs
@@ -6,6 +6,7 @@ macro_rules! f_bench {
             mod [<$F:lower>] {
                 use super::*;
                 use ark_ff::{Field, PrimeField, UniformRand};
+                use ark_std::rand::RngCore;
                 field_common!($bench_group_name, $F);
                 sqrt!($bench_group_name, $F);
                 prime_field!($bench_group_name, $F);
@@ -404,6 +405,16 @@ macro_rules! prime_field {
                     f[i].into_bigint()
                 })
             });
+            let u64s = (0..SAMPLES)
+                .map(|_| rng.next_u64())
+                .collect::<Vec<_>>();
+            conversions.bench_function("From u64", |b| {
+                let mut i = 0;
+                b.iter(|| {
+                    i = (i + 1) % SAMPLES;
+                    <$F>::from_u64(u64s[i])
+                })
+            }); 
             conversions.finish()
         }
     };

--- a/ec/src/lib.rs
+++ b/ec/src/lib.rs
@@ -28,7 +28,11 @@ use ark_std::{
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
     vec::*,
 };
-pub use scalar_mul::{variable_base::VariableBaseMSM, ScalarMul};
+pub use scalar_mul::{
+    fixed_base::FixedBase,
+    variable_base::VariableBaseMSM,
+    ScalarMul,
+};
 use zeroize::Zeroize;
 
 pub use ark_ff::AdditiveGroup;

--- a/ec/src/scalar_mul/fixed_base.rs
+++ b/ec/src/scalar_mul/fixed_base.rs
@@ -1,0 +1,98 @@
+use ark_ff::{BigInteger, PrimeField};
+use ark_std::{cfg_iter, cfg_iter_mut, vec::Vec};
+
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+
+use super::ScalarMul;
+
+pub struct FixedBase;
+
+impl FixedBase {
+    pub fn get_mul_window_size(num_scalars: usize) -> usize {
+        if num_scalars < 32 {
+            3
+        } else {
+            super::ln_without_floats(num_scalars)
+        }
+    }
+
+    pub fn get_window_table<T: ScalarMul>(
+        scalar_size: usize,
+        window: usize,
+        g: T,
+    ) -> Vec<Vec<T::MulBase>> {
+        let in_window = 1 << window;
+        let outerc = (scalar_size + window - 1) / window;
+        let last_in_window = 1 << (scalar_size - (outerc - 1) * window);
+
+        let mut multiples_of_g = vec![vec![T::zero(); in_window]; outerc];
+
+        let mut g_outer = g;
+        let mut g_outers = Vec::with_capacity(outerc);
+        for _ in 0..outerc {
+            g_outers.push(g_outer);
+            for _ in 0..window {
+                g_outer.double_in_place();
+            }
+        }
+        cfg_iter_mut!(multiples_of_g)
+            .enumerate()
+            .take(outerc)
+            .zip(g_outers)
+            .for_each(|((outer, multiples_of_g), g_outer)| {
+                let cur_in_window = if outer == outerc - 1 {
+                    last_in_window
+                } else {
+                    in_window
+                };
+
+                let mut g_inner = T::zero();
+                for inner in multiples_of_g.iter_mut().take(cur_in_window) {
+                    *inner = g_inner;
+                    g_inner += &g_outer;
+                }
+            });
+        cfg_iter!(multiples_of_g)
+            .map(|s| T::batch_convert_to_mul_base(s))
+            .collect()
+    }
+
+    pub fn windowed_mul<T: ScalarMul>(
+        outerc: usize,
+        window: usize,
+        multiples_of_g: &[Vec<<T as ScalarMul>::MulBase>],
+        scalar: &T::ScalarField,
+    ) -> T {
+        let modulus_size = T::ScalarField::MODULUS_BIT_SIZE as usize;
+        let scalar_val = scalar.into_bigint().to_bits_le();
+
+        let mut res = T::from(multiples_of_g[0][0]);
+        for outer in 0..outerc {
+            let mut inner = 0usize;
+            for i in 0..window {
+                if outer * window + i < modulus_size && scalar_val[outer * window + i] {
+                    inner |= 1 << i;
+                }
+            }
+            res += &multiples_of_g[outer][inner];
+        }
+        res
+    }
+
+    // TODO use const-generics for the scalar size and window
+    // TODO use iterators of iterators of T::Affine instead of taking owned Vec
+    pub fn msm<T: ScalarMul>(
+        scalar_size: usize,
+        window: usize,
+        table: &[Vec<<T as ScalarMul>::MulBase>],
+        v: &[T::ScalarField],
+    ) -> Vec<T> {
+        let outerc = (scalar_size + window - 1) / window;
+        assert!(outerc <= table.len());
+
+        cfg_iter!(v)
+            .map(|e| Self::windowed_mul::<T>(outerc, window, table, e))
+            .collect::<Vec<_>>()
+    }
+}

--- a/ec/src/scalar_mul/mod.rs
+++ b/ec/src/scalar_mul/mod.rs
@@ -2,6 +2,7 @@ pub mod glv;
 pub mod wnaf;
 
 pub mod variable_base;
+pub mod fixed_base;
 
 use crate::{
     short_weierstrass::{Affine, Projective, SWCurveConfig},

--- a/ff/Cargo.toml
+++ b/ff/Cargo.toml
@@ -40,6 +40,7 @@ serde.workspace = true
 serde_json.workspace = true
 serde_derive.workspace = true
 hex.workspace = true
+rand = "0.8"
 
 [features]
 default = []

--- a/ff/Cargo.toml
+++ b/ff/Cargo.toml
@@ -31,7 +31,7 @@ digest = { workspace = true, features = ["alloc"] }
 itertools.workspace = true
 
 [dev-dependencies]
-ark-test-curves = { workspace = true, features = [ "bls12_381_curve", "mnt6_753", "secp256k1"] }
+ark-test-curves = { workspace = true, features = [ "bls12_381_curve", "mnt6_753", "secp256k1", "bn254"] }
 blake2.workspace = true
 sha3.workspace = true
 sha2.workspace = true

--- a/ff/Cargo.toml
+++ b/ff/Cargo.toml
@@ -30,16 +30,16 @@ num-bigint.workspace = true
 digest = { workspace = true, features = ["alloc"] }
 itertools.workspace = true
 
-# [dev-dependencies]
-# ark-test-curves = { workspace = true, features = [ "bls12_381_curve", "mnt6_753", "secp256k1"] }
-# blake2.workspace = true
-# sha3.workspace = true
-# sha2.workspace = true
-# libtest-mimic.workspace = true
-# serde.workspace = true
-# serde_json.workspace = true
-# serde_derive.workspace = true
-# hex.workspace = true
+[dev-dependencies]
+ark-test-curves = { workspace = true, features = [ "bls12_381_curve", "mnt6_753", "secp256k1"] }
+blake2.workspace = true
+sha3.workspace = true
+sha2.workspace = true
+libtest-mimic.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+serde_derive.workspace = true
+hex.workspace = true
 
 [features]
 default = []

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -678,6 +678,18 @@ impl<const N: usize> AsRef<[u64]> for BigInt<N> {
     }
 }
 
+impl<const N: usize> From<u128> for BigInt<N> {
+    #[inline]
+    fn from(val: u128) -> BigInt<N> {
+        let mut repr = Self::default();
+        repr.0[0] = val as u64;
+        if N > 1 {
+            repr.0[1] = (val >> 64) as u64;
+        }
+        repr
+    }
+}
+
 impl<const N: usize> From<u64> for BigInt<N> {
     #[inline]
     fn from(val: u64) -> BigInt<N> {
@@ -976,6 +988,7 @@ pub trait BigInteger:
     + Zeroize
     + AsMut<[u64]>
     + AsRef<[u64]>
+    + From<u128>
     + From<u64>
     + From<u32>
     + From<u16>

--- a/ff/src/const_helpers.rs
+++ b/ff/src/const_helpers.rs
@@ -277,6 +277,35 @@ impl<const N: usize> R2Buffer<N> {
     }
 }
 
+/// Helper function to add two N+1 limb big integers, with 1 low limb and N high limbs.
+pub(super) const fn add_bigint_plus_one<const N: usize>(
+    a: (u64, [u64; N]),
+    b: (u64, [u64; N]),
+) -> ((u64, [u64; N]), bool) {
+    let (mut a_lo, mut a_hi) = a;
+    let (b_lo, b_hi) = b;
+    let mut carry: u64;
+
+    // Add low u64 limb manually
+    let tmp = (a_lo as u128) + (b_lo as u128);
+    a_lo = tmp as u64;
+    carry = (tmp >> 64) as u64;
+
+    // Add high N limbs manually
+    let mut i = 0;
+    while i < N {
+        let tmp = (a_hi[i] as u128) + (b_hi[i] as u128) + (carry as u128);
+        a_hi[i] = tmp as u64;
+        carry = (tmp >> 64) as u64;
+        i += 1;
+    }
+
+    // Final carry indicates overflow
+    let final_carry_occurred = carry != 0;
+
+    ((a_lo, a_hi), final_carry_occurred)
+}
+
 mod tests {
     #[test]
     fn test_mul_buffer_correctness() {

--- a/ff/src/const_helpers.rs
+++ b/ff/src/const_helpers.rs
@@ -277,35 +277,6 @@ impl<const N: usize> R2Buffer<N> {
     }
 }
 
-/// Helper function to add two N+1 limb big integers, with 1 low limb and N high limbs.
-pub(super) const fn add_bigint_plus_one<const N: usize>(
-    a: (u64, [u64; N]),
-    b: (u64, [u64; N]),
-) -> ((u64, [u64; N]), bool) {
-    let (mut a_lo, mut a_hi) = a;
-    let (b_lo, b_hi) = b;
-    let mut carry: u64;
-
-    // Add low u64 limb manually
-    let tmp = (a_lo as u128) + (b_lo as u128);
-    a_lo = tmp as u64;
-    carry = (tmp >> 64) as u64;
-
-    // Add high N limbs manually
-    let mut i = 0;
-    while i < N {
-        let tmp = (a_hi[i] as u128) + (b_hi[i] as u128) + (carry as u128);
-        a_hi[i] = tmp as u64;
-        carry = (tmp >> 64) as u64;
-        i += 1;
-    }
-
-    // Final carry indicates overflow
-    let final_carry_occurred = carry != 0;
-
-    ((a_lo, a_hi), final_carry_occurred)
-}
-
 mod tests {
     #[test]
     fn test_mul_buffer_correctness() {

--- a/ff/src/fields/models/fp/mod.rs
+++ b/ff/src/fields/models/fp/mod.rs
@@ -65,6 +65,9 @@ pub trait FpConfig<const N: usize>: Send + Sync + 'static + Sized {
     /// which works for every modulus.
     const SQRT_PRECOMP: Option<SqrtPrecomputation<Fp<Self, N>>>;
 
+    /// Precomputed lookup table for values 0..2^16 in Montgomery form.
+    const SMALL_ELEMENT_MONTGOMERY_PRECOMP: [Fp<Self, N>; PRECOMP_TABLE_SIZE];
+
     /// Set a += b.
     fn add_assign(a: &mut Fp<Self, N>, b: &Fp<Self, N>);
 
@@ -97,6 +100,10 @@ pub trait FpConfig<const N: usize>: Send + Sync + 'static + Sized {
     /// Convert a field element to an integer in the range `0..(Self::MODULUS -
     /// 1)`.
     fn into_bigint(other: Fp<Self, N>) -> BigInt<N>;
+
+    /// Creates a field element from a `u64`. 
+    /// Returns `None` if the `u64` is larger than or equal to the modulus.
+    fn from_u64(val: u64) -> Option<Fp<Self, N>>;
 }
 
 /// Represents an element of the prime field F_p, where `p == P::MODULUS`.
@@ -357,6 +364,11 @@ impl<P: FpConfig<N>, const N: usize> PrimeField for Fp<P, N> {
 
     fn into_bigint(self) -> BigInt<N> {
         P::into_bigint(self)
+    }
+
+    #[inline]
+    fn from_u64(r: u64) -> Option<Self> {
+        P::from_u64(r)
     }
 }
 

--- a/ff/src/fields/models/fp/montgomery_backend.rs
+++ b/ff/src/fields/models/fp/montgomery_backend.rs
@@ -936,6 +936,34 @@ impl<T: MontConfig<N>, const N: usize> Fp<MontBackend<T, N>, N> {
         }
     }
 
+    /// Multiply by a u128.
+    /// Uses optimized mul_u64 if the input fits within u64,
+    /// otherwise falls back to standard multiplication.
+    #[inline(always)]
+    pub fn mul_u128(self, other: u128) -> Self {
+        if other <= u64::MAX as u128 {
+            self.mul_u64(other as u64)
+        } else {
+            // Fallback: Convert u128 to Fp and multiply.
+            // Assumes From<u128> is implemented for Fp.
+            self * Self::from(other)
+        }
+    }
+
+    /// Multiply by an i128.
+    /// Uses optimized mul_i64 if the input fits within i64,
+    /// otherwise falls back to standard multiplication.
+    #[inline(always)]
+    pub fn mul_i128(self, other: i128) -> Self {
+        if other >= i64::MIN as i128 && other <= i64::MAX as i128 {
+            self.mul_i64(other as i64)
+        } else {
+            // Fallback: Convert i128 to Fp and multiply.
+            // Assumes From<i128> is implemented for Fp.
+            self * Self::from(other)
+        }
+    }
+
     const fn const_is_valid(&self) -> bool {
         crate::const_for!((i in 0..N) {
             if (self.0).0[N - i - 1] < T::MODULUS.0[N - i - 1] {

--- a/ff/src/fields/models/fp/montgomery_backend.rs
+++ b/ff/src/fields/models/fp/montgomery_backend.rs
@@ -924,6 +924,18 @@ impl<T: MontConfig<N>, const N: usize> Fp<MontBackend<T, N>, N> {
         Self::new_unchecked(BigInt::<N>::new(result_bigint))
     }
 
+    /// Multiply by an i64.
+    #[inline(always)]
+    pub fn mul_i64(self, other: i64) -> Self {
+        if other >= 0 {
+            // Multiply by the positive value directly
+            self.mul_u64(other as u64)
+        } else {
+            // Multiply by the absolute value and then negate the result
+            -(self.mul_u64((-other) as u64))
+        }
+    }
+
     const fn const_is_valid(&self) -> bool {
         crate::const_for!((i in 0..N) {
             if (self.0).0[N - i - 1] < T::MODULUS.0[N - i - 1] {

--- a/ff/src/fields/prime.rs
+++ b/ff/src/fields/prime.rs
@@ -57,6 +57,10 @@ pub trait PrimeField:
     /// Converts an element of the prime field into an integer in the range 0..(p - 1).
     fn into_bigint(self) -> Self::BigInt;
 
+    /// Creates a field element from a `u64`. 
+    /// Returns `None` if the `u64` is larger than or equal to the modulus.
+    fn from_u64(val: u64) -> Option<Self>;
+
     /// Reads bytes in big-endian, and converts them to a field element.
     /// If the integer represented by `bytes` is larger than the modulus `p`, this method
     /// performs the appropriate reduction.

--- a/serialize/src/impls.rs
+++ b/serialize/src/impls.rs
@@ -105,6 +105,56 @@ impl_uint!(u8);
 impl_uint!(u16);
 impl_uint!(u32);
 impl_uint!(u64);
+impl_uint!(u128);
+impl_uint!(i8);
+impl_uint!(i16);
+impl_uint!(i32);
+impl_uint!(i64);
+impl_uint!(i128);
+
+impl CanonicalSerialize for isize {
+    #[inline]
+    fn serialize_with_mode<W: Write>(
+        &self,
+        mut writer: W,
+        _compress: Compress,
+    ) -> Result<(), SerializationError> {
+        Ok(writer.write_all(&((*self) as i64).to_le_bytes())?)
+    }
+
+    #[inline]
+    fn serialized_size(&self, _compress: Compress) -> usize {
+        core::mem::size_of::<i64>()
+    }
+}
+
+impl Valid for isize {
+    #[inline]
+    fn check(&self) -> Result<(), SerializationError> {
+        Ok(())
+    }
+
+    #[inline]
+    fn batch_check<'a>(_batch: impl Iterator<Item = &'a Self>) -> Result<(), SerializationError>
+    where
+        Self: 'a,
+    {
+        Ok(())
+    }
+}
+
+impl CanonicalDeserialize for isize {
+    #[inline]
+    fn deserialize_with_mode<R: Read>(
+        mut reader: R,
+        _compress: Compress,
+        _validate: Validate,
+    ) -> Result<Self, SerializationError> {
+        let mut bytes = [0u8; core::mem::size_of::<i64>()];
+        reader.read_exact(&mut bytes)?;
+        Ok(<i64>::from_le_bytes(bytes) as Self)
+    }
+}
 
 impl CanonicalSerialize for usize {
     #[inline]

--- a/test-curves/Cargo.toml
+++ b/test-curves/Cargo.toml
@@ -83,6 +83,7 @@ harness = false
 name = "small_mul"
 path = "benches/small_mul.rs"
 harness = false
+required-features = ["bn254"]
 
 [[bench]]
 name = "bn254"

--- a/test-curves/Cargo.toml
+++ b/test-curves/Cargo.toml
@@ -47,6 +47,10 @@ bn384_small_two_adicity_scalar_field = []
 bn384_small_two_adicity_base_field = []
 bn384_small_two_adicity_curve = [ "bn384_small_two_adicity_scalar_field", "bn384_small_two_adicity_base_field" ]
 
+bn254_scalar_field = []
+bn254_base_field = []
+bn254 = [ "bn254_scalar_field", "bn254_base_field" ]
+
 secp256k1 = []
 
 [[bench]]
@@ -79,3 +83,9 @@ name = "field_mul_u64"
 path = "benches/field_mul_u64.rs"
 harness = false
 required-features = ["secp256k1"]
+
+[[bench]]
+name = "bn254"
+path = "benches/bn254.rs"
+harness = false
+required-features = ["bn254"]

--- a/test-curves/Cargo.toml
+++ b/test-curves/Cargo.toml
@@ -19,6 +19,7 @@ package.metadata.release.workspace = true
 ark-std = { workspace = true, default-features = false }
 ark-ff = { workspace = true, default-features = false }
 ark-ec = { workspace = true, default-features = false }
+ark-ff-macros = { workspace = true, default-features = false }
 
 [dev-dependencies]
 ark-serialize  = { workspace = true, default-features = false }

--- a/test-curves/Cargo.toml
+++ b/test-curves/Cargo.toml
@@ -79,10 +79,10 @@ path = "benches/mnt6_753.rs"
 harness = false
 
 [[bench]]
-name = "field_mul_u64"
-path = "benches/field_mul_u64.rs"
+name = "small_mul"
+path = "benches/small_mul.rs"
 harness = false
-required-features = ["secp256k1"]
+required-features = ["bn254"]
 
 [[bench]]
 name = "bn254"

--- a/test-curves/Cargo.toml
+++ b/test-curves/Cargo.toml
@@ -24,6 +24,7 @@ ark-ec = { workspace = true, default-features = false }
 ark-serialize  = { workspace = true, default-features = false }
 ark-algebra-test-templates = { workspace = true, default-features = false }
 ark-algebra-bench-templates = { workspace = true, default-features = false }
+criterion = { version = "0.5", features = ["html_reports"] }
 
 [features]
 default = []
@@ -72,3 +73,9 @@ harness = false
 name = "mnt6_753"
 path = "benches/mnt6_753.rs"
 harness = false
+
+[[bench]]
+name = "field_mul_u64"
+path = "benches/field_mul_u64.rs"
+harness = false
+required-features = ["secp256k1"]

--- a/test-curves/Cargo.toml
+++ b/test-curves/Cargo.toml
@@ -82,10 +82,8 @@ harness = false
 name = "small_mul"
 path = "benches/small_mul.rs"
 harness = false
-required-features = ["bn254"]
 
 [[bench]]
 name = "bn254"
 path = "benches/bn254.rs"
 harness = false
-required-features = ["bn254"]

--- a/test-curves/Cargo.toml
+++ b/test-curves/Cargo.toml
@@ -83,7 +83,6 @@ harness = false
 name = "small_mul"
 path = "benches/small_mul.rs"
 harness = false
-required-features = ["bn254"]
 
 [[bench]]
 name = "bn254"

--- a/test-curves/benches/bn254.rs
+++ b/test-curves/benches/bn254.rs
@@ -1,0 +1,6 @@
+use ark_algebra_bench_templates::{bench, criterion_main, field_common, paste, prime_field, sqrt};
+// Import BN254 types
+use ark_test_curves::bn254::{Fq, Fr, G1Projective as G1};
+
+// Instantiate benchmarks for BN254
+bench!(Name = "BN254", Group = G1, ScalarField = Fr, BaseField = Fq,);

--- a/test-curves/benches/field_mul_u64.rs
+++ b/test-curves/benches/field_mul_u64.rs
@@ -1,0 +1,67 @@
+use ark_ff::{Field, UniformRand};
+use ark_std::rand::{rngs::StdRng, Rng, SeedableRng};
+use ark_test_curves::secp256k1::Fr;
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn mul_u64_bench(c: &mut Criterion) {
+    const SAMPLES: usize = 1000;
+    // Use a fixed seed for reproducibility
+    let mut rng = StdRng::seed_from_u64(0u64);
+
+    let a_s = (0..SAMPLES)
+        .map(|_| Fr::rand(&mut rng))
+        .collect::<Vec<_>>();
+    let b_s = (0..SAMPLES)
+        .map(|_| rng.gen::<u64>())
+        .collect::<Vec<_>>();
+    // Convert u64 to Fr for standard multiplication benchmark
+    let b_fr_s = b_s.iter().map(|&b| Fr::from(b)).collect::<Vec<_>>();
+
+    // Generate another set of random Fr elements for addition
+    let c_s = (0..SAMPLES)
+        .map(|_| Fr::rand(&mut rng))
+        .collect::<Vec<_>>();
+
+    let mut group = c.benchmark_group("Fr Arithmetic Comparison");
+
+    group.bench_function("mul_u64", |bench| {
+        let mut i = 0;
+        bench.iter(|| {
+            i = (i + 1) % SAMPLES;
+            // Make sure the computation is not optimized away
+            criterion::black_box(a_s[i].mul_u64(b_s[i]))
+        })
+    });
+
+    group.bench_function("standard mul (Fr * Fr::from(u64))", |bench| {
+        let mut i = 0;
+        bench.iter(|| {
+            i = (i + 1) % SAMPLES;
+            // Make sure the computation is not optimized away
+            criterion::black_box(a_s[i] * b_fr_s[i])
+        })
+    });
+
+    group.bench_function("Addition (Fr + Fr)", |bench| {
+        let mut i = 0;
+        bench.iter(|| {
+            i = (i + 1) % SAMPLES;
+            // Make sure the computation is not optimized away
+            criterion::black_box(a_s[i] + c_s[i])
+        })
+    });
+
+    group.bench_function("Square (Fr)", |bench| {
+        let mut i = 0;
+        bench.iter(|| {
+            i = (i + 1) % SAMPLES;
+            // Make sure the computation is not optimized away
+            criterion::black_box(a_s[i].square())
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, mul_u64_bench);
+criterion_main!(benches); 

--- a/test-curves/benches/small_mul.rs
+++ b/test-curves/benches/small_mul.rs
@@ -1,247 +1,9 @@
 use ark_ff::UniformRand;
 use ark_std::rand::{rngs::StdRng, Rng, SeedableRng};
-use ark_test_curves::secp256k1::{Fr, FrConfig};
+use ark_test_curves::bn254::{Fr, FrConfig};
 use criterion::{criterion_group, criterion_main, Criterion};
-use ark_ff::BigInteger;
-use ark_ff::BigInt;
-use ark_ff::MontConfig;
-use ark_ff_macros::unroll_for_loops;
-
-const N: usize = 4;
 
 // Hack: copy over the helper functions from the Montgomery backend to be benched
-
-/// Subtract two N+1 limb big integers (represented as low u64 and high N limbs).
-/// Returns the N+1 limb result and a boolean indicating if a borrow occurred.
-#[unroll_for_loops(8)]
-#[inline(always)]
-fn sub_bigint_plus_one<const N: usize>(
-    a: (u64, [u64; N]),
-    b: (u64, [u64; N]),
-) -> ((u64, [u64; N]), bool) {
-    let (mut a_lo, mut a_hi) = a;
-    let (b_lo, b_hi) = b;
-    let mut borrow_bool: bool = false;
-
-    // Subtract low u64 limb using overflowing_sub
-    // Equivalent to (result, borrow_out) = a_lo.borrowing_sub(b_lo, borrow_bool)
-    let (diff_lo, borrow1_lo) = a_lo.overflowing_sub(b_lo);
-    let (res_lo, borrow2_lo) = diff_lo.overflowing_sub(borrow_bool as u64);
-    a_lo = res_lo;
-    borrow_bool = borrow1_lo || borrow2_lo; // Update borrow for next limb
-
-    // Subtract high N limbs
-    for i in 0..N {
-        // Equivalent to (res_hi, borrow_out_hi) = a_hi[i].borrowing_sub(b_hi[i], borrow_bool)
-        let (diff_hi, borrow1_hi) = a_hi[i].overflowing_sub(b_hi[i]);
-        let (res_hi, borrow2_hi) = diff_hi.overflowing_sub(borrow_bool as u64);
-        a_hi[i] = res_hi;
-        borrow_bool = borrow1_hi || borrow2_hi; // Update borrow for next iteration
-    }
-
-    // Final borrow indicates if the result is negative (b > a)
-    let final_borrow_occurred = borrow_bool;
-
-    ((a_lo, a_hi), final_borrow_occurred)
-}
-
-/// Compare two N+1 limb big integers (represented as low u64 and high N limbs).
-#[unroll_for_loops(8)]
-#[inline(always)]
-fn compare_bigint_plus_one<const N: usize>(
-    a: (u64, [u64; N]),
-    b: (u64, [u64; N]),
-) -> core::cmp::Ordering {
-    // Compare high N limbs first, from most significant (N-1) down to 0
-    for i in (0..N).rev() {
-        if a.1[i] > b.1[i] {
-            return core::cmp::Ordering::Greater;
-        } else if a.1[i] < b.1[i] {
-            return core::cmp::Ordering::Less;
-        }
-    }
-    // High limbs are equal, compare the low u64 limb
-    if a.0 > b.0 {
-        return core::cmp::Ordering::Greater;
-    } else if a.0 < b.0 {
-        return core::cmp::Ordering::Less;
-    }
-    // All limbs are equal
-    return core::cmp::Ordering::Equal;
-}
-
-/// Helper to extract N limbs from an N+1 limb value, asserting the high limb is zero.
-#[unroll_for_loops(4)]
-#[inline(always)]
-fn get_n_limbs_from_n_plus_one<const N: usize>(val: (u64, [u64; N])) -> BigInt<N> {
-    debug_assert!(val.1[N-1] == 0, "High limb must be zero to extract N limbs");
-    let mut limbs = [0u64; N];
-    limbs[0] = val.0;
-    if N > 1 {
-        for i in 0..N-1 {
-            limbs[i + 1] = val.1[i];
-        }
-    }
-    BigInt::<N>(limbs)
-}
-
-/// Original conditional subtraction logic for Barrett reduction.
-/// Takes an N+1 limb intermediate result `r_tmp` and returns the N-limb final result.
-/// Performs up to 2 conditional subtractions, instead of 1 in the optimized version.
-#[inline(always)]
-fn _barrett_cond_subtract<T: MontConfig<N>, const N: usize>(r_tmp: (u64, [u64; N])) -> [u64; N] {
-     // Final conditional subtractions (optimized based on spare bits)
-    let final_limbs: [u64; N];
-
-    if T::MODULUS_NUM_SPARE_BITS >= 1 {
-        // Case S >= 1: 2P fits in N limbs (T::MODULUS_TIMES_2_NPLUS1.1[N-1] == 0)
-        let p2_n_limbs = T::MODULUS_TIMES_2_N;
-
-        if T::MODULUS_NUM_SPARE_BITS >= 2 {
-            // Optimization for S >= 2: r_tmp = c - m*2p < 4p already fits in N limbs
-            let mut r_n_limbs = get_n_limbs_from_n_plus_one::<N>(r_tmp);
-
-            // Conditional subtraction 1 (if r >= 2P) using N limbs
-            if r_n_limbs >= p2_n_limbs {
-                r_n_limbs.sub_with_borrow(&p2_n_limbs); // Ignore borrow
-            }
-            // Conditional subtraction 2 (if r >= P) using N limbs
-            if r_n_limbs >= T::MODULUS {
-                r_n_limbs.sub_with_borrow(&T::MODULUS); // Ignore borrow
-            }
-            final_limbs = r_n_limbs.0;
-        } else {
-            // Case S == 1: r_tmp = c - m*2p might temporarily exceed N limbs
-            let r_geq_2p = compare_bigint_plus_one(r_tmp, T::MODULUS_TIMES_2_NPLUS1) != core::cmp::Ordering::Less;
-            let mut temp_r_n_limbs_arr = [0u64; N];
-
-            if r_geq_2p {
-                // Since 2P fits in N limbs, subtracting it from r_tmp might use the high limb r_tmp.1[N-1]
-                let (sub_res, sub_borrow) = sub_bigint_plus_one(r_tmp, T::MODULUS_TIMES_2_NPLUS1);
-                // After subtracting 2P, the result MUST fit in N limbs
-                debug_assert!(sub_res.1[N-1] == 0, "High limb must be 0 after 2P subtraction when S=1");
-                debug_assert!(!sub_borrow, "Borrow should not occur when subtracting 2P for S=1");
-                temp_r_n_limbs_arr[0] = sub_res.0;
-                 if N > 1 {
-                    // Use loop for potential const compatibility
-                    let mut i = 0;
-                    while i < N - 1 {
-                        temp_r_n_limbs_arr[i + 1] = sub_res.1[i];
-                        i += 1;
-                    }
-                 }
-            } else {
-                // r_tmp was already < 2P.
-                // If r_geq_2p is false, r_tmp < 2P. Since 2P fits in N limbs, r_tmp must also fit.
-                 temp_r_n_limbs_arr = get_n_limbs_from_n_plus_one::<N>(r_tmp).0;
-            }
-            let mut r_n_limbs = BigInt::<N>(temp_r_n_limbs_arr);
-
-            // Conditional subtraction 2 (if r >= P) using N limbs
-            // At this point, r_n_limbs holds the value r < 2P fitting in N limbs
-            if r_n_limbs >= T::MODULUS {
-                r_n_limbs.sub_with_borrow(&T::MODULUS); // Ignore borrow
-            }
-            final_limbs = r_n_limbs.0;
-        }
-    } else {
-        // Case S == 0: Use (N+1)-limb helpers throughout
-        let mut current_r = r_tmp; // (u64, [u64; N])
-
-        // Conditional subtraction 1: if r >= 2p
-        if compare_bigint_plus_one(current_r, T::MODULUS_TIMES_2_NPLUS1) != core::cmp::Ordering::Less {
-            current_r = sub_bigint_plus_one(current_r, T::MODULUS_TIMES_2_NPLUS1).0;
-        }
-        // Now current_r = c mod 2p, represented as (lo, hi)
-
-        // Conditional subtraction 2: if r >= p
-        if compare_bigint_plus_one(current_r, T::MODULUS_NPLUS1) != core::cmp::Ordering::Less { // if r >= p
-             let (sub_res, sub_borrow) = sub_bigint_plus_one(current_r, T::MODULUS_NPLUS1);
-             // Result MUST fit in N limbs now
-             final_limbs = get_n_limbs_from_n_plus_one::<N>(sub_res).0;
-             debug_assert!(!sub_borrow, "Borrow should not occur when subtracting P for S=0");
-        } else {
-             // r was already < P
-             final_limbs = get_n_limbs_from_n_plus_one::<N>(current_r).0;
-        }
-    }
-    final_limbs
-}
-
-/// Optimized conditional subtraction logic for Barrett reduction using comparisons.
-/// Takes an N+1 limb intermediate result `r_tmp` and returns the N-limb final result.
-#[unroll_for_loops(4)]
-#[inline(always)]
-fn barrett_cond_subtract_optimized<T: MontConfig<N>, const N: usize>(r_tmp: (u64, [u64; N])) -> [u64; N] {
-    let final_limbs: [u64; N];
-    let mut r_n = get_n_limbs_from_n_plus_one::<N>(r_tmp); // Make r_n mutable
-
-    // Compare with 2p (N+1 limbs)
-    let compare_2p = if T::MODULUS_NUM_SPARE_BITS >= 2 {
-        compare_bigint_plus_one(r_tmp, T::MODULUS_TIMES_2_NPLUS1)
-    } else {
-        r_n.cmp(&T::MODULUS_TIMES_2_N)
-    };
-
-    if compare_2p != core::cmp::Ordering::Less { // r_tmp >= 2p
-        // Compare with 3p (N+1 limbs)
-        let compare_3p = if T::MODULUS_NUM_SPARE_BITS >= 2 {
-            compare_bigint_plus_one(r_tmp, T::MODULUS_TIMES_3_NPLUS1)
-        } else {
-            r_n.cmp(&T::MODULUS_TIMES_3_N)
-        };
-
-        if compare_3p != core::cmp::Ordering::Less { // r_tmp >= 3p
-            // Subtract 3p
-            if T::MODULUS_NUM_SPARE_BITS >= 2 { // 3p fits in N limbs
-                let borrow_n = r_n.sub_with_borrow(&T::MODULUS_TIMES_3_N); // Call on mutable r_n, assign return to borrow_n
-                debug_assert!(!borrow_n, "Borrow should not occur subtracting 3p (S>=2)");
-                final_limbs = r_n.0; // Use r_n directly
-            } else { // Use N+1 limb subtraction
-                let (res_n1, borrow_n1) = sub_bigint_plus_one(r_tmp, T::MODULUS_TIMES_3_NPLUS1);
-                debug_assert!(!borrow_n1, "Borrow should not occur subtracting 3p (S<2)");
-                final_limbs = get_n_limbs_from_n_plus_one::<N>(res_n1).0;
-            }
-        } else { // 2p <= r_tmp < 3p
-            // Subtract 2p
-            if T::MODULUS_NUM_SPARE_BITS >= 1 { // 2p fits in N limbs
-                let borrow_n = r_n.sub_with_borrow(&T::MODULUS_TIMES_2_N); // Call on mutable r_n, assign return to borrow_n
-                 debug_assert!(!borrow_n, "Borrow should not occur subtracting 2p (S>=1)");
-                final_limbs = r_n.0; // Use r_n directly
-            } else { // s == 0, use N+1 limb subtraction
-                let (res_n1, borrow_n1) = sub_bigint_plus_one(r_tmp, T::MODULUS_TIMES_2_NPLUS1);
-                debug_assert!(!borrow_n1, "Borrow should not occur subtracting 2p (S=0)");
-                final_limbs = get_n_limbs_from_n_plus_one::<N>(res_n1).0;
-            }
-        }
-    } else { // r_tmp < 2p
-        // Compare with p (N+1 limbs)
-        let compare_p = if T::MODULUS_NUM_SPARE_BITS >= 1 {
-            compare_bigint_plus_one(r_tmp, T::MODULUS_NPLUS1)
-        } else {
-            r_n.cmp(&T::MODULUS)
-        };
-
-        if compare_p != core::cmp::Ordering::Less { // p <= r_tmp < 2p
-            // Subtract p
-            // P always fits in N limbs if S>=1. If S=0, use N+1.
-            if T::MODULUS_NUM_SPARE_BITS >= 1 { // N limb subtraction suffices
-                let borrow_n = r_n.sub_with_borrow(&T::MODULUS); // Call on mutable r_n, assign return to borrow_n
-                debug_assert!(!borrow_n, "Borrow should not occur subtracting p (S>=1)");
-                final_limbs = r_n.0; // Use r_n directly
-            } else { // s == 0, use N+1 limb subtraction
-                 let (res_n1, borrow_n1) = sub_bigint_plus_one(r_tmp, T::MODULUS_NPLUS1);
-                 debug_assert!(!borrow_n1, "Borrow should not occur subtracting p (S=0)");
-                 final_limbs = get_n_limbs_from_n_plus_one::<N>(res_n1).0;
-            }
-        } else { // r_tmp < p
-            // Subtract 0 (No-op)
-            // Result must already fit in N limbs
-            final_limbs = get_n_limbs_from_n_plus_one::<N>(r_tmp).0;
-        }
-    }
-    final_limbs
-}
 
 fn mul_small_bench(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
@@ -278,40 +40,9 @@ fn mul_small_bench(c: &mut Criterion) {
         .map(|_| Fr::rand(&mut rng))
         .collect::<Vec<_>>();
 
-    let barrett_inputs = (0..SAMPLES)
-        .map(|_| {
-            let lo = rng.gen::<u64>();
-            let mut hi = [0u64; N];
-            for i in 0..N {
-                hi[i] = rng.gen::<u64>();
-            }
-            (lo, hi)
-        })
-        .collect::<Vec<_>>();
-
     let mut group = c.benchmark_group("Fr Arithmetic Comparison");
 
-    // --- Conditional Subtraction Benchmarks ---
-    group.bench_function("barrett_cond_subtract", |bench| {
-        let mut i = 0;
-        bench.iter(|| {
-            i = (i + 1) % SAMPLES;
-            // Call using the FrConfig type explicitly
-            criterion::black_box(_barrett_cond_subtract::<FrConfig, N>(barrett_inputs[i]))
-        })
-    });
-
-    group.bench_function("barrett_cond_subtract_optimized", |bench| {
-        let mut i = 0;
-        bench.iter(|| {
-            i = (i + 1) % SAMPLES;
-            // Call using the FrConfig type explicitly
-            criterion::black_box(barrett_cond_subtract_optimized::<FrConfig, N>(barrett_inputs[i]))
-        })
-    });
-    // --- End Conditional Subtraction Benchmarks ---
-
-    group.bench_function("mul_u64 (full)", |bench| {
+    group.bench_function("mul_u64", |bench| {
         let mut i = 0;
         bench.iter(|| {
             i = (i + 1) % SAMPLES;
@@ -319,9 +50,17 @@ fn mul_small_bench(c: &mut Criterion) {
         })
     });
 
+    group.bench_function("mul_i64", |bench| {
+        let mut i = 0;
+        bench.iter(|| {
+            i = (i + 1) % SAMPLES;
+            criterion::black_box(a_s[i].mul_i64(b_i64_s[i]))
+        })
+    });
+
     // Note: results might be worse than in real applications due to branch prediction being wrong
     // 50% of the time
-    group.bench_function("mul_u128 (full)", |bench| {
+    group.bench_function("mul_u128", |bench| {
         let mut i = 0;
         bench.iter(|| {
             i = (i + 1) % SAMPLES;

--- a/test-curves/benches/small_mul.rs
+++ b/test-curves/benches/small_mul.rs
@@ -1,9 +1,9 @@
 use ark_ff::{Field, UniformRand};
 use ark_std::rand::{rngs::StdRng, Rng, SeedableRng};
-use ark_test_curves::secp256k1::Fr;
+use ark_test_curves::bn254::Fr;
 use criterion::{criterion_group, criterion_main, Criterion};
 
-fn mul_u64_bench(c: &mut Criterion) {
+fn mul_small_bench(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
     // Use a fixed seed for reproducibility
     let mut rng = StdRng::seed_from_u64(0u64);
@@ -11,11 +11,24 @@ fn mul_u64_bench(c: &mut Criterion) {
     let a_s = (0..SAMPLES)
         .map(|_| Fr::rand(&mut rng))
         .collect::<Vec<_>>();
-    let b_s = (0..SAMPLES)
+
+    let b_u64_s = (0..SAMPLES)
         .map(|_| rng.gen::<u64>())
         .collect::<Vec<_>>();
     // Convert u64 to Fr for standard multiplication benchmark
-    let b_fr_s = b_s.iter().map(|&b| Fr::from(b)).collect::<Vec<_>>();
+    let b_fr_s = b_u64_s.iter().map(|&b| Fr::from(b)).collect::<Vec<_>>();
+
+    let b_i64_s = (0..SAMPLES)
+        .map(|_| rng.gen::<i64>())
+        .collect::<Vec<_>>();
+
+    let b_u128_s = (0..SAMPLES)
+        .map(|_| rng.gen::<u128>())
+        .collect::<Vec<_>>();
+
+    let b_i128_s = (0..SAMPLES)
+        .map(|_| rng.gen::<i128>())
+        .collect::<Vec<_>>();
 
     // Generate another set of random Fr elements for addition
     let c_s = (0..SAMPLES)
@@ -29,7 +42,31 @@ fn mul_u64_bench(c: &mut Criterion) {
         bench.iter(|| {
             i = (i + 1) % SAMPLES;
             // Make sure the computation is not optimized away
-            criterion::black_box(a_s[i].mul_u64(b_s[i]))
+            criterion::black_box(a_s[i].mul_u64(b_u64_s[i]))
+        })
+    });
+
+    group.bench_function("mul_i64", |bench| {
+        let mut i = 0;
+        bench.iter(|| {
+            i = (i + 1) % SAMPLES;
+            criterion::black_box(a_s[i].mul_i64(b_i64_s[i]))
+        })
+    });
+
+    group.bench_function("mul_u128", |bench| {
+        let mut i = 0;
+        bench.iter(|| {
+            i = (i + 1) % SAMPLES;
+            criterion::black_box(a_s[i].mul_u128(b_u128_s[i]))
+        })
+    });
+
+    group.bench_function("mul_i128", |bench| {
+        let mut i = 0;
+        bench.iter(|| {
+            i = (i + 1) % SAMPLES;
+            criterion::black_box(a_s[i].mul_i128(b_i128_s[i]))
         })
     });
 
@@ -63,5 +100,5 @@ fn mul_u64_bench(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, mul_u64_bench);
+criterion_group!(benches, mul_small_bench);
 criterion_main!(benches); 

--- a/test-curves/benches/small_mul.rs
+++ b/test-curves/benches/small_mul.rs
@@ -1,6 +1,6 @@
 use ark_ff::UniformRand;
 use ark_std::rand::{rngs::StdRng, Rng, SeedableRng};
-use ark_test_curves::secp256k1::{Fr, FqConfig, FrConfig};
+use ark_test_curves::secp256k1::{Fr, FrConfig};
 use criterion::{criterion_group, criterion_main, Criterion};
 use ark_ff::BigInteger;
 use ark_ff::BigInt;

--- a/test-curves/benches/small_mul.rs
+++ b/test-curves/benches/small_mul.rs
@@ -1,7 +1,322 @@
-use ark_ff::{Field, UniformRand};
+use ark_ff::UniformRand;
 use ark_std::rand::{rngs::StdRng, Rng, SeedableRng};
-use ark_test_curves::bn254::Fr;
+use ark_test_curves::bn254::{Fr, FqConfig};
 use criterion::{criterion_group, criterion_main, Criterion};
+use ark_ff::BigInteger;
+use ark_ff::BigInt;
+use ark_ff::MontConfig;
+use ark_ff_macros::unroll_for_loops;
+use ark_ff::biginteger::arithmetic as fa;
+
+const N: usize = 4;
+
+// Hack: copy over the helper functions from the Montgomery backend to be benched
+
+/// Multiply a N-limb big integer with a u64, producing a N+1 limb result,
+/// represented as a tuple of a u64 low limb and an array of N high limbs.
+#[unroll_for_loops(8)]
+#[inline(always)]
+fn bigint_mul_by_u64<const N: usize>(val: &[u64; N], other: u64) -> (u64, [u64; N]) {
+    let mut result_hi = [0u64; N];
+    let mut carry: u64; // Start with carry = 0
+
+    // Calculate the full 128-bit product of the lowest limb
+    let prod128_0: u128 = (val[0] as u128) * (other as u128);
+    let result_lo = prod128_0 as u64; // Lowest limb of the result
+    carry = (prod128_0 >> 64) as u64; // Carry into the high part
+
+    // Iterate through the remaining limbs of the input BigInt
+    for i in 1..N {
+        // Calculate the full 128-bit product of the current limb and the u64 multiplier
+        let prod128: u128 = (val[i] as u128) * (other as u128);
+
+        // Add the carry from the previous limb's computation
+        let sum128: u128 = prod128 + (carry as u128);
+
+        // The lower 64 bits of the sum become the current result limb (in the high part)
+        result_hi[i - 1] = sum128 as u64; // Store in result_hi[0] to result_hi[N-2]
+
+        // The upper 64 bits of the sum become the carry for the next limb
+        carry = (sum128 >> 64) as u64;
+    }
+
+    // After the loop, the final carry is the highest limb (N-th limb of the high part)
+    result_hi[N - 1] = carry;
+
+    (result_lo, result_hi)
+}
+
+/// Multiply a N+1 limb big integer (represented as low u64 and high N limbs) with a u64,
+/// producing a N+1 limb result in the same format.
+/// Also returns a boolean indicating if there was a carry out (overflow).
+#[unroll_for_loops(8)]
+#[inline(always)]
+fn bigint_plus_one_mul_by_u64<const N: usize>(
+    val_lo: &u64,
+    val_hi: &[u64; N],
+    other: u64,
+) -> (u64, [u64; N], bool) {
+    let mut result_hi = [0u64; N];
+
+    // Stage 1: Multiply the low limb
+    let prod_lo: u128 = (*val_lo as u128) * (other as u128);
+    let result_lo = prod_lo as u64;
+    let mut carry = (prod_lo >> 64) as u64;
+
+    // Stage 2: Multiply the high N limbs
+    for i in 0..N {
+        let prod_hi: u128 = (val_hi[i] as u128) * (other as u128) + (carry as u128);
+        result_hi[i] = prod_hi as u64;
+        carry = (prod_hi >> 64) as u64;
+    }
+
+    // Final carry indicates overflow
+    let overflow = carry != 0;
+    (result_lo, result_hi, overflow)
+}
+
+/// Subtract two N+1 limb big integers (represented as low u64 and high N limbs).
+/// Returns the N+1 limb result and a boolean indicating if a borrow occurred.
+#[unroll_for_loops(8)]
+#[inline(always)]
+fn sub_bigint_plus_one<const N: usize>(
+    a: (u64, [u64; N]),
+    b: (u64, [u64; N]),
+) -> ((u64, [u64; N]), bool) {
+    let (mut a_lo, mut a_hi) = a;
+    let (b_lo, b_hi) = b;
+    let mut borrow_bool: bool = false;
+
+    // Subtract low u64 limb using overflowing_sub
+    // Equivalent to (result, borrow_out) = a_lo.borrowing_sub(b_lo, borrow_bool)
+    let (diff_lo, borrow1_lo) = a_lo.overflowing_sub(b_lo);
+    let (res_lo, borrow2_lo) = diff_lo.overflowing_sub(borrow_bool as u64);
+    a_lo = res_lo;
+    borrow_bool = borrow1_lo || borrow2_lo; // Update borrow for next limb
+
+    // Subtract high N limbs
+    for i in 0..N {
+        // Equivalent to (res_hi, borrow_out_hi) = a_hi[i].borrowing_sub(b_hi[i], borrow_bool)
+        let (diff_hi, borrow1_hi) = a_hi[i].overflowing_sub(b_hi[i]);
+        let (res_hi, borrow2_hi) = diff_hi.overflowing_sub(borrow_bool as u64);
+        a_hi[i] = res_hi;
+        borrow_bool = borrow1_hi || borrow2_hi; // Update borrow for next iteration
+    }
+
+    // Final borrow indicates if the result is negative (b > a)
+    let final_borrow_occurred = borrow_bool;
+
+    ((a_lo, a_hi), final_borrow_occurred)
+}
+
+/// Compare two N+1 limb big integers (represented as low u64 and high N limbs).
+#[unroll_for_loops(8)]
+#[inline(always)]
+fn compare_bigint_plus_one<const N: usize>(
+    a: (u64, [u64; N]),
+    b: (u64, [u64; N]),
+) -> core::cmp::Ordering {
+    // Compare high N limbs first, from most significant (N-1) down to 0
+    for i in (0..N).rev() {
+        if a.1[i] > b.1[i] {
+            return core::cmp::Ordering::Greater;
+        } else if a.1[i] < b.1[i] {
+            return core::cmp::Ordering::Less;
+        }
+    }
+    // High limbs are equal, compare the low u64 limb
+    if a.0 > b.0 {
+        return core::cmp::Ordering::Greater;
+    } else if a.0 < b.0 {
+        return core::cmp::Ordering::Less;
+    }
+    // All limbs are equal
+    return core::cmp::Ordering::Equal;
+}
+
+/// Multiply a N-limb big integer with a u128, producing a N+2 limb result,
+/// represented as a tuple of an array of 2 low limbs and an array of N high limbs.
+#[unroll_for_loops(8)]
+#[inline(always)]
+fn bigint_mul_by_u128<const N: usize>(val: &BigInt<N>, other: u128) -> ([u64; 2], [u64; N]) {
+    let other_lo = other as u64;
+    let other_hi = (other >> 64) as u64;
+
+    // Compute partial products
+    // p1 = val * other_lo -> (N+1) limbs: (p1_lo: u64, p1_hi: [u64; N])
+    let (p1_lo, p1_hi) = bigint_mul_by_u64(&val.0, other_lo);
+    // p2 = val * other_hi -> (N+1) limbs: (p2_lo: u64, p2_hi: [u64; N])
+    let (p2_lo, p2_hi) = bigint_mul_by_u64(&val.0, other_hi);
+
+    // Calculate the final result r = p1 + (p2 << 64) limb by limb.
+    // p1       : [p1_lo, p1_hi[0], ..., p1_hi[N-1]]
+    // p2 << 64 : [0, p2_lo, p2_hi[0], ..., p2_hi[N-1]]
+    // Sum (r)  : [r_lo[0], r_lo[1], r_hi[0], ..., r_hi[N-1]] (N+2 limbs)
+
+    let mut r_lo = [0u64; 2];
+    let mut r_hi = [0u64; N];
+    let mut carry: u64 = 0;
+
+    // r_lo[0] = p1_lo + 0 + carry (carry is initially 0)
+    r_lo[0] = p1_lo;
+    // carry = 0; // Initial carry is 0
+
+    // Calculate r_lo[1] = p1_hi[0] + p2_lo + carry (limb 1)
+    r_lo[1] = p1_hi[0]; // Initialize with p1 limb
+    carry = fa::adc(&mut r_lo[1], p2_lo, carry); // Add p2 limb and carry
+
+    // Calculate r_hi[0] to r_hi[N-1] (limbs 2 to N+1)
+    for i in 0..N {
+        let p1_limb = if i + 1 < N { p1_hi[i + 1] } else { 0 }; // Limb p1[i+2]
+        let p2_limb = p2_hi[i]; // Limb p2[i+1]
+
+        // r_hi[i] = p1_limb + p2_limb + carry
+        r_hi[i] = p1_limb; // Initialize with p1 limb
+        carry = fa::adc(&mut r_hi[i], p2_limb, carry); // Add p2 limb and carry
+    }
+
+    // The final carry MUST be zero for the result to fit in N+2 limbs.
+    debug_assert!(carry == 0, "Overflow in bigint_mul_by_u128");
+
+    (r_lo, r_hi)
+}
+
+/// Helper function to perform Barrett reduction from N+1 limbs to N limbs.
+/// Input `c` is represented as `(u64, [u64; N])`.
+/// Output is the N-limb result `[u64; N]`.
+#[unroll_for_loops(4)]
+#[inline(always)]
+fn barrett_reduce_nplus1_to_n<T: MontConfig<N>, const N: usize>(c: (u64, [u64; N])) -> [u64; N] {
+    let (c_lo, c_hi) = c; // c_lo is the lowest limb, c_hi holds the top N limbs
+
+    // Compute tilde_c = floor(c / R') = floor(c / 2^MODULUS_BITS)
+    // This involves the top two limbs of the N+1 limb number `c`.
+    // The highest limb is c_hi[N-1]. The second highest is c_hi[N-2].
+    // Assume that `N >= 1`
+    let tilde_c: u64 = if T::MODULUS_HAS_SPARE_BIT {
+        let high_limb = c_hi[N-1];
+        let second_high_limb = if N > 1 { c_hi[N-2] } else { c_lo }; // Use c_lo if N=1
+        (high_limb << T::MODULUS_NUM_SPARE_BITS) + (second_high_limb >> (64 - T::MODULUS_NUM_SPARE_BITS))
+    } else {
+        c_hi[N-1] // If no spare bits, tilde_c is just the highest limb
+    };
+
+    // Estimate m = floor( (tilde_c * BARRETT_MU) / r )
+    let m: u64 = ((tilde_c as u128 * T::BARRETT_MU as u128) >> 64) as u64;
+
+    // Compute m * 2p (N+1 limbs)
+    let (m2p_lo, m2p_hi, _m2p_carry) = bigint_plus_one_mul_by_u64::<N>(
+        &T::MODULUS_TIMES_2_NPLUS1.0, // Low limb of 2p
+        &T::MODULUS_TIMES_2_NPLUS1.1, // High N limbs of 2p
+        m,
+    );
+    debug_assert!(_m2p_carry == false, "Overflow calculating m * 2p");
+    let m_times_2p = (m2p_lo, m2p_hi);
+
+    // Compute r_tmp = c - m * 2p (N+1 limbs)
+    let (r_tmp, _) = sub_bigint_plus_one(c, m_times_2p); // r_tmp = (r_tmp_lo, r_tmp_hi)
+
+    // Final conditional subtractions (optimized based on spare bits)
+    let final_limbs: [u64; N];
+
+    if T::MODULUS_NUM_SPARE_BITS >= 1 {
+        // Case S >= 1: 2P fits in N limbs (T::MODULUS_TIMES_2_NPLUS1.1[N-1] == 0)
+        let mut p2_n_limbs_arr = [0u64; N];
+        p2_n_limbs_arr[0] = T::MODULUS_TIMES_2_NPLUS1.0;
+        if N > 1 {
+            p2_n_limbs_arr[1..N].copy_from_slice(&T::MODULUS_TIMES_2_NPLUS1.1[0..(N-1)]);
+        }
+        let p2_n_limbs = BigInt::<N>(p2_n_limbs_arr);
+
+        if T::MODULUS_NUM_SPARE_BITS >= 2 {
+            // Optimization for S >= 2: r_tmp = c - m*2p < 4p already fits in N limbs
+            debug_assert!(r_tmp.1[N - 1] == 0, "High limb of r_tmp should be 0 for S >= 2 before subtractions");
+
+            let mut r_n_limbs_arr = [0u64; N];
+            r_n_limbs_arr[0] = r_tmp.0; // Low limb
+            if N > 1 {
+                r_n_limbs_arr[1..N].copy_from_slice(&r_tmp.1[0..(N - 1)]); // Lower N-1 limbs of high part
+            }
+            let mut r_n_limbs = BigInt::<N>(r_n_limbs_arr);
+
+            // Conditional subtraction 1 (if r >= 2P) using N limbs
+            if r_n_limbs >= p2_n_limbs {
+                r_n_limbs.sub_with_borrow(&p2_n_limbs); // Ignore borrow
+            }
+            // Conditional subtraction 2 (if r >= P) using N limbs
+            if r_n_limbs >= T::MODULUS {
+                r_n_limbs.sub_with_borrow(&T::MODULUS); // Ignore borrow
+            }
+            final_limbs = r_n_limbs.0;
+        } else {
+            // Case S == 1: r_tmp = c - m*2p might temporarily exceed N limbs
+            let r_geq_2p = compare_bigint_plus_one(r_tmp, T::MODULUS_TIMES_2_NPLUS1) != core::cmp::Ordering::Less;
+            let mut temp_r_n_limbs_arr = [0u64; N];
+
+            if r_geq_2p {
+                // Since 2P fits in N limbs, subtracting it from r_tmp might use the high limb r_tmp.1[N-1]
+                let (sub_res, sub_borrow) = sub_bigint_plus_one(r_tmp, T::MODULUS_TIMES_2_NPLUS1);
+                // After subtracting 2P, the result MUST fit in N limbs
+                debug_assert!(sub_res.1[N-1] == 0, "High limb must be 0 after 2P subtraction when S=1");
+                debug_assert!(!sub_borrow, "Borrow should not occur when subtracting 2P for S=1");
+                temp_r_n_limbs_arr[0] = sub_res.0;
+                 if N > 1 {
+                    temp_r_n_limbs_arr[1..N].copy_from_slice(&sub_res.1[0..(N-1)]);
+                 }
+            } else {
+                // r_tmp was already < 2P.
+                // If r_geq_2p is false, r_tmp < 2P. Since 2P fits in N limbs, r_tmp must also fit.
+                debug_assert!(r_tmp.1[N - 1] == 0, "High limb must be 0 if r < 2P and S=1");
+                temp_r_n_limbs_arr[0] = r_tmp.0;
+                if N > 1 {
+                    temp_r_n_limbs_arr[1..N].copy_from_slice(&r_tmp.1[0..(N - 1)]);
+                }
+            }
+            let mut r_n_limbs = BigInt::<N>(temp_r_n_limbs_arr);
+
+            // Conditional subtraction 2 (if r >= P) using N limbs
+            // At this point, r_n_limbs holds the value r < 2P fitting in N limbs
+            if r_n_limbs >= T::MODULUS {
+                r_n_limbs.sub_with_borrow(&T::MODULUS); // Ignore borrow
+            }
+            final_limbs = r_n_limbs.0;
+        }
+    } else {
+        // Case S == 0: Use (N+1)-limb helpers throughout
+        let mut current_r = r_tmp; // (u64, [u64; N])
+
+        // Conditional subtraction 1: if r >= 2p
+        if compare_bigint_plus_one(current_r, T::MODULUS_TIMES_2_NPLUS1) != core::cmp::Ordering::Less {
+            current_r = sub_bigint_plus_one(current_r, T::MODULUS_TIMES_2_NPLUS1).0;
+        }
+        // Now current_r = c mod 2p, represented as (lo, hi)
+
+        // Conditional subtraction 2: if r >= p
+        if compare_bigint_plus_one(current_r, T::MODULUS_NPLUS1) != core::cmp::Ordering::Less { // if r >= p
+             let (sub_res, sub_borrow) = sub_bigint_plus_one(current_r, T::MODULUS_NPLUS1);
+             // Result MUST fit in N limbs now
+             debug_assert!(sub_res.1[N-1] == 0, "High limb must be 0 after P subtraction when S=0");
+             debug_assert!(!sub_borrow, "Borrow should not occur when subtracting P for S=0");
+             let mut r_n_limbs_arr = [0u64; N];
+             r_n_limbs_arr[0] = sub_res.0;
+             if N > 1 {
+                r_n_limbs_arr[1..N].copy_from_slice(&sub_res.1[0..(N-1)]);
+             }
+             final_limbs = r_n_limbs_arr;
+        } else {
+             // r was already < P
+             debug_assert!(current_r.1[N - 1] == 0, "High limb must be 0 if r < P and S=0");
+             let mut r_n_limbs_arr = [0u64; N];
+             r_n_limbs_arr[0] = current_r.0;
+             if N > 1 {
+                r_n_limbs_arr[1..N].copy_from_slice(&current_r.1[0..(N - 1)]);
+             }
+             final_limbs = r_n_limbs_arr;
+        }
+    }
+    
+    final_limbs
+}
 
 fn mul_small_bench(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
@@ -11,12 +326,15 @@ fn mul_small_bench(c: &mut Criterion) {
     let a_s = (0..SAMPLES)
         .map(|_| Fr::rand(&mut rng))
         .collect::<Vec<_>>();
+    let a_limbs_s = a_s.iter().map(|a| a.0.0).collect::<Vec<_>>();
 
     let b_u64_s = (0..SAMPLES)
         .map(|_| rng.gen::<u64>())
         .collect::<Vec<_>>();
     // Convert u64 to Fr for standard multiplication benchmark
     let b_fr_s = b_u64_s.iter().map(|&b| Fr::from(b)).collect::<Vec<_>>();
+
+    let b_u64_as_u128_s = b_u64_s.iter().map(|&b| b as u128).collect::<Vec<_>>();
 
     let b_i64_s = (0..SAMPLES)
         .map(|_| rng.gen::<i64>())
@@ -35,26 +353,38 @@ fn mul_small_bench(c: &mut Criterion) {
         .map(|_| Fr::rand(&mut rng))
         .collect::<Vec<_>>();
 
+    let barrett_inputs = (0..SAMPLES)
+        .map(|_| {
+            let lo = rng.gen::<u64>();
+            let mut hi = [0u64; N];
+            for i in 0..N {
+                hi[i] = rng.gen::<u64>();
+            }
+            (lo, hi)
+        })
+        .collect::<Vec<_>>();
+
     let mut group = c.benchmark_group("Fr Arithmetic Comparison");
 
-    group.bench_function("mul_u64", |bench| {
+    group.bench_function("mul_u64 (full)", |bench| {
         let mut i = 0;
         bench.iter(|| {
             i = (i + 1) % SAMPLES;
-            // Make sure the computation is not optimized away
             criterion::black_box(a_s[i].mul_u64(b_u64_s[i]))
         })
     });
 
-    group.bench_function("mul_i64", |bench| {
+    group.bench_function("bigint_mul_by_u64 (helper)", |bench| {
         let mut i = 0;
         bench.iter(|| {
             i = (i + 1) % SAMPLES;
-            criterion::black_box(a_s[i].mul_i64(b_i64_s[i]))
+            criterion::black_box(bigint_mul_by_u64::<N>(&a_limbs_s[i], b_u64_s[i]))
         })
     });
 
-    group.bench_function("mul_u128", |bench| {
+    // Note: results might be worse than in real applications due to branch prediction being wrong
+    // 50% of the time
+    group.bench_function("mul_u128 (full)", |bench| {
         let mut i = 0;
         bench.iter(|| {
             i = (i + 1) % SAMPLES;
@@ -62,20 +392,60 @@ fn mul_small_bench(c: &mut Criterion) {
         })
     });
 
-    group.bench_function("mul_i128", |bench| {
+    group.bench_function("bigint_mul_by_u128 (helper)", |bench| {
         let mut i = 0;
         bench.iter(|| {
             i = (i + 1) % SAMPLES;
-            criterion::black_box(a_s[i].mul_i128(b_i128_s[i]))
+            let val_bigint = BigInt::<N>(a_limbs_s[i]);
+            criterion::black_box(bigint_mul_by_u128::<N>(&val_bigint, b_u128_s[i]))
         })
     });
 
-    group.bench_function("standard mul (Fr * Fr::from(u64))", |bench| {
+    // group.bench_function("mul_i128", |bench| {
+    //     let mut i = 0;
+    //     bench.iter(|| {
+    //         i = (i + 1) % SAMPLES;
+    //         criterion::black_box(a_s[i].mul_i128(b_i128_s[i]))
+    //     })
+    // });
+
+    group.bench_function("barrett_reduce_nplus1_to_n (helper)", |bench| {
         let mut i = 0;
         bench.iter(|| {
             i = (i + 1) % SAMPLES;
-            // Make sure the computation is not optimized away
+            criterion::black_box(
+                barrett_reduce_nplus1_to_n::<FqConfig, N>(barrett_inputs[i])
+            )
+        })
+    });
+
+    group.bench_function("standard mul (Fr * Fr)", |bench| {
+        let mut i = 0;
+        bench.iter(|| {
+            i = (i + 1) % SAMPLES;
             criterion::black_box(a_s[i] * b_fr_s[i])
+        })
+    });
+
+    // Benchmark mul_u128 specifically with inputs known to fit in u64
+    group.bench_function("mul_u128 (u64 inputs)", |bench| {
+        let mut i = 0;
+        bench.iter(|| {
+            i = (i + 1) % SAMPLES;
+            // Call mul_u128 but provide a u64 input cast to u128
+            criterion::black_box(a_s[i].mul_u128(b_u64_as_u128_s[i]))
+        })
+    });
+
+    // Benchmark the auxiliary function directly (assuming it's made public)
+    // Note: Requires mul_u128_aux to be pub in montgomery_backend.rs
+    // Need to import it if not already done via wildcard/specific import
+    // Let's assume it's accessible via a_s[i].mul_u128_aux(...) for now
+    group.bench_function("mul_u128_aux (u128 inputs)", |bench| {
+        let mut i = 0;
+        bench.iter(|| {
+            i = (i + 1) % SAMPLES;
+            criterion::black_box(a_s[i].mul_u128_aux(b_u128_s[i]))
         })
     });
 
@@ -83,17 +453,7 @@ fn mul_small_bench(c: &mut Criterion) {
         let mut i = 0;
         bench.iter(|| {
             i = (i + 1) % SAMPLES;
-            // Make sure the computation is not optimized away
             criterion::black_box(a_s[i] + c_s[i])
-        })
-    });
-
-    group.bench_function("Square (Fr)", |bench| {
-        let mut i = 0;
-        bench.iter(|| {
-            i = (i + 1) % SAMPLES;
-            // Make sure the computation is not optimized away
-            criterion::black_box(a_s[i].square())
         })
     });
 

--- a/test-curves/src/bn254/fq.rs
+++ b/test-curves/src/bn254/fq.rs
@@ -1,0 +1,13 @@
+use ark_ff::fields::{Fp256, MontBackend, MontConfig};
+
+/// Defines the parameters for the base field `Fq` of the BN254 curve.
+#[derive(MontConfig)]
+#[modulus = "21888242871839275222246405745257275088696311157297823662689037894645226208583"]
+#[generator = "3"]
+pub struct FqConfig;
+
+/// The base field `Fq` of the BN254 curve.
+pub type Fq = Fp256<MontBackend<FqConfig, 4>>;
+
+pub const FQ_ONE: Fq = ark_ff::MontFp!("1");
+pub const FQ_ZERO: Fq = ark_ff::MontFp!("0");

--- a/test-curves/src/bn254/fr.rs
+++ b/test-curves/src/bn254/fr.rs
@@ -1,0 +1,17 @@
+use ark_ff::fields::{Fp256, MontBackend, MontConfig};
+// use ark_ff_macros::{MontConfig, MontFp}; // Keep MontFp for constants
+
+/// Defines the parameters for the scalar field `Fr` of the BN254 curve.
+#[derive(MontConfig)]
+#[modulus = "21888242871839275222246405745257275088548364400416034343698204186575808495617"]
+#[generator = "5"]
+// Define Small subgroup base/power if needed, otherwise macro defaults are fine
+// #[small_subgroup_base = "3"]
+// #[small_subgroup_power = "2"]
+pub struct FrConfig;
+
+/// The scalar field `Fr` of the BN254 curve.
+pub type Fr = Fp256<MontBackend<FrConfig, 4>>;
+
+pub const FR_ONE: Fr = ark_ff::MontFp!("1");
+pub const FR_ZERO: Fr = ark_ff::MontFp!("0");

--- a/test-curves/src/bn254/g1.rs
+++ b/test-curves/src/bn254/g1.rs
@@ -1,0 +1,53 @@
+use ark_ec::models::short_weierstrass::{
+    Affine, Projective, SWCurveConfig,
+};
+use ark_ec::CurveConfig;
+use ark_ff::{Field, MontFp, Zero, AdditiveGroup};
+
+use crate::bn254::{Fq, Fr}; // Assuming Fq is defined in fq.rs
+
+#[derive(Clone, Default, PartialEq, Eq)]
+pub struct G1Config;
+
+impl CurveConfig for G1Config {
+    type BaseField = Fq;
+    type ScalarField = Fr;
+
+    /// COFACTOR = 1
+    const COFACTOR: &'static [u64] = &[1];
+
+    /// COFACTOR_INV = COFACTOR^{-1} mod r = 1
+    const COFACTOR_INV: Self::ScalarField = Fr::ONE;
+}
+
+impl SWCurveConfig for G1Config {
+    /// COEFF_A = 0
+    const COEFF_A: Self::BaseField = Fq::ZERO;
+
+    /// COEFF_B = 3
+    const COEFF_B: Self::BaseField = MontFp!("3");
+
+    /// AFFINE_GENERATOR_COEFFS = (G1_GENERATOR_X, G1_GENERATOR_Y)
+    const GENERATOR: Affine<Self> = Affine::new_unchecked(G1_GENERATOR_X, G1_GENERATOR_Y);
+
+    #[inline(always)]
+    fn mul_by_a(_base: Self::BaseField) -> Self::BaseField {
+        // A is zero, avoids a multiply
+        Self::BaseField::zero()
+    }
+
+    #[inline(always)]
+    fn is_in_correct_subgroup_assuming_on_curve(_p: &Affine<Self>) -> bool {
+        // The cofactor is 1, so any point on the curve is in the correct subgroup.
+        true
+    }
+}
+
+/// G1_GENERATOR_X = 1
+pub const G1_GENERATOR_X: Fq = MontFp!("1");
+
+/// G1_GENERATOR_Y = 2
+pub const G1_GENERATOR_Y: Fq = MontFp!("2");
+
+pub type G1Affine = Affine<G1Config>;
+pub type G1Projective = Projective<G1Config>;

--- a/test-curves/src/bn254/mod.rs
+++ b/test-curves/src/bn254/mod.rs
@@ -1,0 +1,19 @@
+#[cfg(feature = "bn254_base_field")]
+pub mod fq;
+#[cfg(feature = "bn254_base_field")]
+pub use fq::*;
+
+#[cfg(feature = "bn254_scalar_field")]
+pub mod fr;
+#[cfg(feature = "bn254_scalar_field")]
+pub use fr::*;
+
+#[cfg(feature = "bn254")] // Use the main bn254 feature
+pub mod g1;
+#[cfg(feature = "bn254")] // Use the main bn254 feature
+pub use g1::*;
+
+// TODO: Define G2, GT, Pairing for BN254 similarly if needed
+
+#[cfg(test)]
+mod test; // Renamed from tests to test.rs

--- a/test-curves/src/bn254/test.rs
+++ b/test-curves/src/bn254/test.rs
@@ -1,0 +1,23 @@
+#![allow(unused_imports)]
+use ark_ec::{
+    models::short_weierstrass::SWCurveConfig, // Keep this as G1 is SW
+    pairing::Pairing,
+    AffineRepr, CurveGroup, PrimeGroup,
+};
+use ark_ff::{Field, One, UniformRand, Zero};
+use ark_std::{rand::Rng, test_rng};
+
+// Add imports for the newly defined types
+use crate::bn254::{Fq, FqConfig, Fr, FrConfig, G1Affine, G1Projective};
+
+use ark_algebra_test_templates::*;
+use ark_std::ops::{AddAssign, MulAssign, SubAssign};
+
+test_field!(fr; Fr; mont_prime_field);
+// Uncomment Fq test
+test_field!(fq; Fq; mont_prime_field);
+
+// Uncomment G1 test for Short Weierstrass
+test_group!(g1; G1Projective; sw);
+
+// Add other tests for G2, Pairing etc. as needed

--- a/test-curves/src/lib.rs
+++ b/test-curves/src/lib.rs
@@ -30,4 +30,7 @@ pub mod bn384_small_two_adicity;
 #[cfg(feature = "secp256k1")]
 pub mod secp256k1;
 
+#[cfg(feature = "bn254")]
+pub mod bn254;
+
 pub mod fp128;

--- a/test-curves/src/lib.rs
+++ b/test-curves/src/lib.rs
@@ -4,6 +4,8 @@ pub use ark_ff::{self, fields::models::*, FftField, Field, LegendreSymbol, MontF
 
 pub use ark_ec::{self, *};
 
+pub use ark_ff_macros::unroll_for_loops;
+
 #[cfg(any(feature = "bls12_381_scalar_field", feature = "bls12_381_curve"))]
 pub mod bls12_381;
 


### PR DESCRIPTION
This branch implements the following:

1. An optimized multiplication of a field element (in Montgomery form) by a u64 value, having the result be in Montgomery form.

This improves upon the prior version in v0.4.2 by using an optimized Barrett reduction instead of full Montgomery reduction. Concretely, we pay for 2N+1 base (u64) multiplications instead of 2N^2+N. And the result is also correctly in Montgomery form, unlike the prior version.

2. Preliminary benchmarks for `mul_u64` shows roughly a 2.4x to 3x decrease in cost compared to regular multiplication (benched over bn254 and secp256k1). This is in contrast to the prior version (w/ full Montgomery reduction) which is only about a ~30% decrease.

3. We added a BN254 backend in `test-curves`. It is missing config for G2 and GT (and hence pairing). These can be added in the future if needed.

4. We added back the `FixedBase` trait in `ark-ec`, which is needed in Jolt for SRS generation.

5. We implemented multiplication by u128 (and hence i128) as well. We aim to maximally re-use logic for simplicity, but at the cost of inefficiency. In particular, this `mul_u128` operation simply does the bignum mult, and then does 2 steps of Barrett reduction. A more optimized version would try to break down this abstraction & enable work sharing between the two steps (see Yuval's blog post). It also might lead to better data efficiency.

Because of this, the current performance of `mul_u128` is on par with regular mul, and of `mul_i128` is 10% worse. This is benched on a M4 Mac.

Note: doing `a.mul_u128(b)` is still faster than doing `a * Fr::from(b)`, since for the latter there are actually _2_ multiplications (one for converting `b` into Montgomery form, and one for the actual multiplication). Therefore, it is still advisable to use `mul_u128` and `mul_i128` in these cases.


TODOs:
1. Improve the performance of mul u128/i128.

Could we have optimized mul u32 / u16 / u8?

2. Add x86 asm derivation for special mul (like with regular mul). Bench how much it changes performance on x86 machines.