### PR TITLE
Yuval Dombs new Mont Mult algorithm implemented inside of Arkworks

### DIFF
--- a/ff-macros/src/lib.rs
+++ b/ff-macros/src/lib.rs
@@ -39,7 +39,7 @@ pub fn to_sign_and_limbs(input: TokenStream) -> TokenStream {
 // This code was adapted from the `PrimeField` Derive Macro in ff-derive.
 #[proc_macro_derive(
     MontConfig,
-    attributes(modulus, generator, small_subgroup_base, small_subgroup_power)
+    attributes(modulus, generator, small_subgroup_base, small_subgroup_power, yd_opt)
 )]
 pub fn mont_config(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     // Parse the type definition
@@ -64,11 +64,15 @@ pub fn mont_config(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let small_subgroup_power: Option<u32> = fetch_attr("small_subgroup_power", &ast.attrs)
         .map(|s| s.parse().expect("small_subgroup_power should be a number"));
 
+    let yd_opt: bool = fetch_attr("yd_opt", &ast.attrs)
+        .map(|s| s.parse().expect("yd_opt should be a boolean"))
+        .unwrap_or(false); // Default to false if not provided
     montgomery::mont_config_helper(
         modulus,
         generator,
         small_subgroup_base,
         small_subgroup_power,
+        yd_opt,
         ast.ident,
     )
     .into()

--- a/ff-macros/src/lib.rs
+++ b/ff-macros/src/lib.rs
@@ -6,14 +6,12 @@
     rust_2021_compatibility
 )]
 #![forbid(unsafe_code)]
-
 use num_bigint::BigUint;
 use proc_macro::TokenStream;
 use syn::{Expr, ExprLit, Item, ItemFn, Lit, Meta};
 
 mod montgomery;
 mod unroll;
-
 pub(crate) mod utils;
 
 #[proc_macro]

--- a/ff-macros/src/montgomery/mod.rs
+++ b/ff-macros/src/montgomery/mod.rs
@@ -86,6 +86,7 @@ pub fn mont_config_helper(
         limbs,
         &modulus_limbs,
         modulus_has_spare_bit,
+        yd_opt,
     );
     let sum_of_products = sum_of_products_impl(limbs, &modulus_limbs);
 

--- a/ff-macros/src/montgomery/mod.rs
+++ b/ff-macros/src/montgomery/mod.rs
@@ -26,6 +26,7 @@ pub fn mont_config_helper(
     generator: BigUint,
     small_subgroup_base: Option<u32>,
     small_subgroup_power: Option<u32>,
+    yd_opt: bool,
     config_name: proc_macro2::Ident,
 ) -> proc_macro2::TokenStream {
     let mut limbs = 1usize;
@@ -75,6 +76,7 @@ pub fn mont_config_helper(
     let double_in_place = double_in_place_impl(modulus_has_spare_bit);
     let mul_assign = mul_assign_impl(
         can_use_no_carry_mul_opt,
+        yd_opt,
         limbs,
         &modulus_limbs,
         modulus_has_spare_bit,
@@ -112,6 +114,9 @@ pub fn mont_config_helper(
                 const GENERATOR: F = ark_ff::MontFp!(#generator);
 
                 const TWO_ADIC_ROOT_OF_UNITY: F = ark_ff::MontFp!(#two_adic_root_of_unity);
+
+                // Include the new YD_OPT constant
+                const YD_OPT: bool = #yd_opt;
 
                 #mixed_radix
 

--- a/ff-macros/src/montgomery/mul.rs
+++ b/ff-macros/src/montgomery/mul.rs
@@ -2,13 +2,151 @@ use quote::quote;
 
 pub(super) fn mul_assign_impl(
     can_use_no_carry_mul_opt: bool,
+    yd_opt: bool,
     num_limbs: usize,
     modulus_limbs: &[u64],
     modulus_has_spare_bit: bool,
 ) -> proc_macro2::TokenStream {
     let mut body = proc_macro2::TokenStream::new();
     let modulus_0 = modulus_limbs[0];
-    if can_use_no_carry_mul_opt {
+    let modulus_1 = modulus_limbs[1];
+    let modulus_2 = modulus_limbs[2];
+    let modulus_3 = modulus_limbs[3];
+
+    const U64_P: [u64; 4] = [
+        0x43e1f593f0000001,
+        0x2833e84879b97091,
+        0xb85045b68181585d,
+        0x30644e72e131a029,
+    ];
+
+    // RIGHT now this is just for BN_255
+    if yd_opt
+        && num_limbs == 4
+        && modulus_0 == U64_P[0]
+        && modulus_1 == U64_P[1]
+        && modulus_2 == U64_P[2]
+        && modulus_3 == U64_P[3]
+    {
+        body.extend(quote! {
+                macro_rules! subarray {
+                ($t:expr, $b: literal, $l: literal) => {
+                {
+                 use seq_macro::seq;
+                 let t = $t;
+                 let mut s = [0;$l];
+
+                // The compiler does not detect out-of-bounds when using `for` therefore `seq!` is used here
+                seq!(i in 0..$l {
+                s[i] = t[$b+i];
+                 });
+                s
+                }
+            };}
+        });
+        //
+        let double_limbs = num_limbs * 2;
+        body.extend(quote! {
+            let mut t = [0u64; #double_limbs];
+            let mut carry = 0;
+
+            (t[0], carry) = fa::carrying_mul_add(a.0.0[0], b.0.0[0], t[0], carry);
+            (t[1], carry) = fa::carrying_mul_add(a.0.0[0], b.0.0[1], t[1], carry);
+            (t[2], carry) = fa::carrying_mul_add(a.0.0[0], b.0.0[2], t[2], carry);
+            (t[3], carry) = fa::carrying_mul_add(a.0.0[0], b.0.0[3], t[3], carry);
+            t[4] = carry;
+            carry = 0;
+            (t[1], carry) = fa::carrying_mul_add(a.0.0[1], b.0.0[0], t[1], carry);
+            (t[2], carry) = fa::carrying_mul_add(a.0.0[1], b.0.0[1], t[2], carry);
+            (t[3], carry) = fa::carrying_mul_add(a.0.0[1], b.0.0[2], t[3], carry);
+            (t[4], carry) = fa::carrying_mul_add(a.0.0[1], b.0.0[3], t[4], carry);
+            t[5] = carry;
+            carry = 0;
+            (t[2], carry) = fa::carrying_mul_add(a.0.0[2], b.0.0[0], t[2], carry);
+            (t[3], carry) = fa::carrying_mul_add(a.0.0[2], b.0.0[1], t[3], carry);
+            (t[4], carry) = fa::carrying_mul_add(a.0.0[2], b.0.0[2], t[4], carry);
+            (t[5], carry) = fa::carrying_mul_add(a.0.0[2], b.0.0[3], t[5], carry);
+            t[6] = carry;
+            carry = 0;
+            (t[3], carry) = fa::carrying_mul_add(a.0.0[3], b.0.0[0], t[3], carry);
+            (t[4], carry) = fa::carrying_mul_add(a.0.0[3], b.0.0[1], t[4], carry);
+            (t[5], carry) = fa::carrying_mul_add(a.0.0[3], b.0.0[2], t[5], carry);
+            (t[6], carry) = fa::carrying_mul_add(a.0.0[3], b.0.0[3], t[6], carry);
+            t[7] = carry;
+        });
+
+        //for i in 0..num_limbs {
+        //    body.extend(quote! { let mut carry = 0u64; });
+        //    for j in 0..num_limbs {
+        //        let k = i + j;
+        //        body.extend(quote!{t[#k] = fa::mac_with_carry(t[#k], (a.0).0[#i], (b.0).0[#j], &mut carry);});
+        //    }
+        //    body.extend(quote! { t[#i + #num_limbs] = carry; });
+        //}
+
+        // The precomputed multiplications!
+        body.extend(quote! {
+            let mut sub_arr = subarray!(t, 3, 5);
+            let mut s_r1 = [0_u64; 5]; // TODO: Make this general later should be num_limbs//2 + 1
+            let mut s_r2 = [0_u64; 5]; // TODO
+            let mut s_r3 = [0_u64; 5]; // TODO
+
+            (s_r1[0], s_r1[1]) = fa::carrying_mul_add(t[0], constants::U64_I3[0], 0, 0);
+            (s_r1[1], s_r1[2]) = fa::carrying_mul_add(t[0], constants::U64_I3[1], s_r1[1], 0);
+            (s_r1[2], s_r1[3]) = fa::carrying_mul_add(t[0], constants::U64_I3[2], s_r1[2], 0);
+            (s_r1[3], s_r1[4]) = fa::carrying_mul_add(t[0], constants::U64_I3[3], s_r1[3], 0);
+
+            (s_r2[0], s_r2[1]) = fa::carrying_mul_add(t[1], constants::U64_I2[0], 0, 0);
+            (s_r2[1], s_r2[2]) = fa::carrying_mul_add(t[1], constants::U64_I2[1], s_r2[1], 0);
+            (s_r2[2], s_r2[3]) = fa::carrying_mul_add(t[1], constants::U64_I2[2], s_r2[2], 0);
+            (s_r2[3], s_r2[4]) = fa::carrying_mul_add(t[1], constants::U64_I2[3], s_r2[3], 0);
+
+            (s_r3[0], s_r3[1]) = fa::carrying_mul_add(t[2], constants::U64_I1[0], 0, 0);
+            (s_r3[1], s_r3[2]) = fa::carrying_mul_add(t[2], constants::U64_I1[1], s_r3[1], 0);
+            (s_r3[2], s_r3[3]) = fa::carrying_mul_add(t[2], constants::U64_I1[2], s_r3[2], 0);
+            (s_r3[3], s_r3[4]) = fa::carrying_mul_add(t[2], constants::U64_I1[3], s_r3[3], 0);
+
+        });
+
+        // mac_with_carry and carrying_mul_add do the same thing -- but using already existing
+        // arkworks helpers to be consistent.
+        // TODO: These constants here are the only things that make this code base not generic, but can
+        // be fixed later.
+        //for i in 0..num_limbs {
+        //    body.extend(quote!{
+        //        s_r1[#i] = fa::mac_with_carry(s_r1[#i], t[0], constants::U64_I3[#i], &mut s_r1[#i+1]);
+        //        s_r2[#i] = fa::mac_with_carry(s_r2[#i], t[1], constants::U64_I2[#i], &mut s_r2[#i+1]);
+        //        s_r3[#i] = fa::mac_with_carry(s_r3[#i], t[2], constants::U64_I1[#i], &mut s_r3[#i+1]);
+        //    });
+        //}
+        //
+        body.extend(quote! {
+        let s = fa::addv(fa::addv(subarray!(t, 3, 5), s_r1), fa::addv(s_r2, s_r3));
+        });
+
+        body.extend(quote! {
+            let m = s[0].wrapping_mul(Self::INV);
+            let mut mp = [0_u64; 5]; // TODO: Make this general later; change this to limbs
+            (mp[0], mp[1]) = fa::carrying_mul_add(m, #modulus_0, mp[0], 0);
+            (mp[1], mp[2]) = fa::carrying_mul_add(m, #modulus_1, mp[1], 0);
+            (mp[2], mp[3]) = fa::carrying_mul_add(m, #modulus_2, mp[2], 0);
+            (mp[3], mp[4]) = fa::carrying_mul_add(m, #modulus_3, mp[3], 0);
+
+        });
+
+        //for i in 0..num_limbs {
+        //    let mod_limb_i = modulus_limbs[i];
+        //    body.extend(quote! {
+        //        mp[#i] = fa::mac_with_carry(mp[#i], m, #mod_limb_i, &mut mp[#i+1]);
+        //    });
+        //}
+
+        // TODO: handle the constants better
+        body.extend(quote! {
+            let r = fa::reduce_ct(subarray!(fa::addv(s, mp), 1, 4), constants::U64_2P);
+            (a.0).0 = r;
+        });
+    } else if can_use_no_carry_mul_opt {
         // This modular multiplication algorithm uses Montgomery
         // reduction for efficient implementation. It also additionally
         // uses the "no-carry optimization" outlined

--- a/ff-macros/src/montgomery/mul.rs
+++ b/ff-macros/src/montgomery/mul.rs
@@ -1,5 +1,4 @@
 use quote::quote;
-
 pub(super) fn mul_assign_impl(
     can_use_no_carry_mul_opt: bool,
     yd_opt: bool,
@@ -19,7 +18,6 @@ pub(super) fn mul_assign_impl(
         0xb85045b68181585d,
         0x30644e72e131a029,
     ];
-
     // RIGHT now this is just for BN_255
     if yd_opt
         && num_limbs == 4
@@ -29,122 +27,128 @@ pub(super) fn mul_assign_impl(
         && modulus_3 == U64_P[3]
     {
         body.extend(quote! {
-                macro_rules! subarray {
-                ($t:expr, $b: literal, $l: literal) => {
-                {
-                 use seq_macro::seq;
-                 let t = $t;
-                 let mut s = [0;$l];
+            // The precomputed multiplications!
 
-                // The compiler does not detect out-of-bounds when using `for` therefore `seq!` is used here
-                seq!(i in 0..$l {
-                s[i] = t[$b+i];
-                 });
-                s
-                }
-            };}
-        });
-        //
-        let double_limbs = num_limbs * 2;
-        body.extend(quote! {
-            let mut t = [0u64; #double_limbs];
-            let mut carry = 0;
+            let (c00hi, c00lo) = fa::mult((a.0).0[0], (b.0).0[0]);
+            let (c01hi, c01lo) = fa::mult((a.0).0[0], (b.0).0[1]);
+            let (c02hi, c02lo) = fa::mult((a.0).0[0], (b.0).0[2]);
+            let (c03hi, c03lo) = fa::mult((a.0).0[0], (b.0).0[3]);
 
-            (t[0], carry) = fa::carrying_mul_add(a.0.0[0], b.0.0[0], t[0], carry);
-            (t[1], carry) = fa::carrying_mul_add(a.0.0[0], b.0.0[1], t[1], carry);
-            (t[2], carry) = fa::carrying_mul_add(a.0.0[0], b.0.0[2], t[2], carry);
-            (t[3], carry) = fa::carrying_mul_add(a.0.0[0], b.0.0[3], t[3], carry);
-            t[4] = carry;
-            carry = 0;
-            (t[1], carry) = fa::carrying_mul_add(a.0.0[1], b.0.0[0], t[1], carry);
-            (t[2], carry) = fa::carrying_mul_add(a.0.0[1], b.0.0[1], t[2], carry);
-            (t[3], carry) = fa::carrying_mul_add(a.0.0[1], b.0.0[2], t[3], carry);
-            (t[4], carry) = fa::carrying_mul_add(a.0.0[1], b.0.0[3], t[4], carry);
-            t[5] = carry;
-            carry = 0;
-            (t[2], carry) = fa::carrying_mul_add(a.0.0[2], b.0.0[0], t[2], carry);
-            (t[3], carry) = fa::carrying_mul_add(a.0.0[2], b.0.0[1], t[3], carry);
-            (t[4], carry) = fa::carrying_mul_add(a.0.0[2], b.0.0[2], t[4], carry);
-            (t[5], carry) = fa::carrying_mul_add(a.0.0[2], b.0.0[3], t[5], carry);
-            t[6] = carry;
-            carry = 0;
-            (t[3], carry) = fa::carrying_mul_add(a.0.0[3], b.0.0[0], t[3], carry);
-            (t[4], carry) = fa::carrying_mul_add(a.0.0[3], b.0.0[1], t[4], carry);
-            (t[5], carry) = fa::carrying_mul_add(a.0.0[3], b.0.0[2], t[5], carry);
-            (t[6], carry) = fa::carrying_mul_add(a.0.0[3], b.0.0[3], t[6], carry);
-            t[7] = carry;
-        });
+            let (c10hi, c10lo) = fa::mult((a.0).0[1], (b.0).0[0]);
+            let (c11hi, c11lo) = fa::mult((a.0).0[1], (b.0).0[1]);
+            let (c12hi, c12lo) = fa::mult((a.0).0[1], (b.0).0[2]);
+            let (c13hi, c13lo) = fa::mult((a.0).0[1], (b.0).0[3]);
 
-        //for i in 0..num_limbs {
-        //    body.extend(quote! { let mut carry = 0u64; });
-        //    for j in 0..num_limbs {
-        //        let k = i + j;
-        //        body.extend(quote!{t[#k] = fa::mac_with_carry(t[#k], (a.0).0[#i], (b.0).0[#j], &mut carry);});
-        //    }
-        //    body.extend(quote! { t[#i + #num_limbs] = carry; });
-        //}
+            let (c20hi, c20lo) = fa::mult((a.0).0[2], (b.0).0[0]);
+            let (c21hi, c21lo) = fa::mult((a.0).0[2], (b.0).0[1]);
+            let (c22hi, c22lo) = fa::mult((a.0).0[2], (b.0).0[2]);
+            let (c23hi, c23lo) = fa::mult((a.0).0[2], (b.0).0[3]);
 
-        // The precomputed multiplications!
-        body.extend(quote! {
-            let mut sub_arr = subarray!(t, 3, 5);
-            let mut s_r1 = [0_u64; 5]; // TODO: Make this general later should be num_limbs//2 + 1
-            let mut s_r2 = [0_u64; 5]; // TODO
-            let mut s_r3 = [0_u64; 5]; // TODO
+            let (c30hi, c30lo) = fa::mult((a.0).0[3], (b.0).0[0]);
+            let (c31hi, c31lo) = fa::mult((a.0).0[3], (b.0).0[1]);
+            let (c32hi, c32lo) = fa::mult((a.0).0[3], (b.0).0[2]);
+            let (c33hi, c33lo) = fa::mult((a.0).0[3], (b.0).0[3]);
 
-            (s_r1[0], s_r1[1]) = fa::carrying_mul_add(t[0], constants::U64_I3[0], 0, 0);
-            (s_r1[1], s_r1[2]) = fa::carrying_mul_add(t[0], constants::U64_I3[1], s_r1[1], 0);
-            (s_r1[2], s_r1[3]) = fa::carrying_mul_add(t[0], constants::U64_I3[2], s_r1[2], 0);
-            (s_r1[3], s_r1[4]) = fa::carrying_mul_add(t[0], constants::U64_I3[3], s_r1[3], 0);
+            let mut c: bool;
+            let mut r0 = 0u128;
+            let mut r1 = 0u128;
+            let mut r2 = 0u128;
+            let mut r3 = 0u128;
 
-            (s_r2[0], s_r2[1]) = fa::carrying_mul_add(t[1], constants::U64_I2[0], 0, 0);
-            (s_r2[1], s_r2[2]) = fa::carrying_mul_add(t[1], constants::U64_I2[1], s_r2[1], 0);
-            (s_r2[2], s_r2[3]) = fa::carrying_mul_add(t[1], constants::U64_I2[2], s_r2[2], 0);
-            (s_r2[3], s_r2[4]) = fa::carrying_mul_add(t[1], constants::U64_I2[3], s_r2[3], 0);
+            (r0, _) = fa::wadd(c00hi, c00lo, r0, false);
 
-            (s_r3[0], s_r3[1]) = fa::carrying_mul_add(t[2], constants::U64_I1[0], 0, 0);
-            (s_r3[1], s_r3[2]) = fa::carrying_mul_add(t[2], constants::U64_I1[1], s_r3[1], 0);
-            (s_r3[2], s_r3[3]) = fa::carrying_mul_add(t[2], constants::U64_I1[2], s_r3[2], 0);
-            (s_r3[3], s_r3[4]) = fa::carrying_mul_add(t[2], constants::U64_I1[3], s_r3[3], 0);
+            (r0, c) = fa::wadd(c01lo, 0u64, r0, false);
+            (r1, _) = fa::wadd(c11hi, c11lo, r1, c);
 
-        });
+            (r0, c) = fa::wadd(c10lo, 0u64, r0, false);
+            (r1, c) = fa::wadd(c12lo, c01hi, r1, c);
+            (r2, _) = fa::wadd(0u64, c12hi, r2, c);
 
-        // mac_with_carry and carrying_mul_add do the same thing -- but using already existing
-        // arkworks helpers to be consistent.
-        // TODO: These constants here are the only things that make this code base not generic, but can
-        // be fixed later.
-        //for i in 0..num_limbs {
-        //    body.extend(quote!{
-        //        s_r1[#i] = fa::mac_with_carry(s_r1[#i], t[0], constants::U64_I3[#i], &mut s_r1[#i+1]);
-        //        s_r2[#i] = fa::mac_with_carry(s_r2[#i], t[1], constants::U64_I2[#i], &mut s_r2[#i+1]);
-        //        s_r3[#i] = fa::mac_with_carry(s_r3[#i], t[2], constants::U64_I1[#i], &mut s_r3[#i+1]);
-        //    });
-        //}
-        //
-        body.extend(quote! {
-        let s = fa::addv(fa::addv(subarray!(t, 3, 5), s_r1), fa::addv(s_r2, s_r3));
-        });
+            (r1, c) = fa::wadd(c21lo, c10hi, r1, false);
+            (r2, _) = fa::wadd(0u64, c21hi, r2, c);
 
-        body.extend(quote! {
-            let m = s[0].wrapping_mul(Self::INV);
-            let mut mp = [0_u64; 5]; // TODO: Make this general later; change this to limbs
-            (mp[0], mp[1]) = fa::carrying_mul_add(m, #modulus_0, mp[0], 0);
-            (mp[1], mp[2]) = fa::carrying_mul_add(m, #modulus_1, mp[1], 0);
-            (mp[2], mp[3]) = fa::carrying_mul_add(m, #modulus_2, mp[2], 0);
-            (mp[3], mp[4]) = fa::carrying_mul_add(m, #modulus_3, mp[3], 0);
+            (r1, c) = fa::wadd(c02hi, c02lo, r1, false);
+            (r2, _) = fa::wadd(c13hi, c13lo, r2, c); // ignore c - limited to input < p
 
-        });
+            (r1, c) = fa::wadd(c20hi, c20lo, r1, false);
+            (r2, _) = fa::wadd(c31hi, c31lo, r2, c); // ignore c - limited to input < p
 
-        //for i in 0..num_limbs {
-        //    let mod_limb_i = modulus_limbs[i];
-        //    body.extend(quote! {
-        //        mp[#i] = fa::mac_with_carry(mp[#i], m, #mod_limb_i, &mut mp[#i+1]);
-        //    });
-        //}
+            (r1, c) = fa::wadd(c03lo, 0u64, r1, false);
+            (r2, c) = fa::wadd(c23lo, c03hi, r2, c);
+            (r3, _) = fa::wadd(0u64, c23hi, r3, c);
 
-        // TODO: handle the constants better
-        body.extend(quote! {
-            let r = fa::reduce_ct(subarray!(fa::addv(s, mp), 1, 4), constants::U64_2P);
-            (a.0).0 = r;
+            (r1, c) = fa::wadd(c30lo, 0u64, r1, false);
+            (r2, c) = fa::wadd(c32lo, c30hi, r2, c);
+            (r3, _) = fa::wadd(0u64, c32hi, r3, c);
+
+           const U64_I2: [u64; 4] = [
+                0x18ee753c76f9dc6f,
+                0x54ad7e14a329e70f,
+                0x2b16366f4f7684df,
+                0x133100d71fdf3579,
+            ];
+            let (r0hi, r0lo) = ((r0 >> 64) as u64, r0 as u64);
+            let (ir000hi, ir000lo) = fa::mult(r0lo, U64_I2[0]);
+            let (ir001hi, ir001lo) = fa::mult(r0lo, U64_I2[1]);
+            let (ir002hi, ir002lo) = fa::mult(r0lo, U64_I2[2]);
+            let (ir003hi, ir003lo) = fa::mult(r0lo, U64_I2[3]);
+            let (ir010hi, ir010lo) = fa::mult(r0hi, U64_I2[0]);
+            let (ir011hi, ir011lo) = fa::mult(r0hi, U64_I2[1]);
+            let (ir012hi, ir012lo) = fa::mult(r0hi, U64_I2[2]);
+            let (ir013hi, ir013lo) = fa::mult(r0hi, U64_I2[3]);
+
+            (r1, c) = fa::wadd(ir000hi, ir000lo, r1, false);
+            (r2, c) = fa::wadd(c22hi, c22lo, r2, c);
+            (r3, _) = fa::wadd(c33hi, c33lo, r3, c);
+
+            (r1, c) = fa::wadd(ir001lo, 0u64, r1, false);
+            (r2, c) = fa::wadd(ir002hi, ir002lo, r2, c);
+            (r3, _) = fa::wadd(0u64, ir003hi, r3, c);
+
+            (r1, c) = fa::wadd(ir010lo, 0u64, r1, false);
+            (r2, c) = fa::wadd(ir003lo, ir001hi, r2, c);
+            (r3, _) = fa::wadd(0u64, ir012hi, r3, c);
+
+            const U64_I1: [u64; 4] = [
+                0x2d3e8053e396ee4d,
+                0xca478dbeab3c92cd,
+                0xb2d8f06f77f52a93,
+                0x24d6ba07f7aa8f04,
+            ];
+            let r1lo = r1 as u64;
+            let (ir100hi, ir100lo) = fa::mult(r1lo, U64_I1[0]);
+            let (ir101hi, ir101lo) = fa::mult(r1lo, U64_I1[1]);
+            let (ir102hi, ir102lo) = fa::mult(r1lo, U64_I1[2]);
+            let (ir103hi, ir103lo) = fa::mult(r1lo, U64_I1[3]);
+
+            (r1, c) = fa::wadd(ir100lo, 0u64, r1, false);
+            (r2, c) = fa::wadd(ir012lo, ir010hi, r2, c);
+            (r3, _) = fa::wadd(ir013hi, ir013lo, r3, c);
+
+            let m = (Self::INV).wrapping_mul((r1 >> 64) as u64);
+            let (m0hi, m0lo) = fa::mult(m, #modulus_0);
+            let (m1hi, m1lo) = fa::mult(m, #modulus_1);
+            let (m2hi, m2lo) = fa::mult(m, #modulus_2);
+            let (m3hi, m3lo) = fa::mult(m, #modulus_3);
+
+            (_, c) = fa::wadd(m0lo, 0u64, r1, false);
+            (r2, c) = fa::wadd(ir011hi, ir011lo, r2, c);
+            (r3, _) = fa::wadd(0u64, ir102hi, r3, c);
+
+            (r2, c) = fa::wadd(ir102lo, ir100hi, r2, false);
+            (r3, _) = fa::wadd(ir103hi, ir103lo, r3, c);
+
+            (r2, c) = fa::wadd(ir101hi, ir101lo, r2, false);
+            (r3, _) = fa::wadd(0u64, m2hi, r3, c);
+
+            (r2, c) = fa::wadd(m2lo, m0hi, r2, false);
+            (r3, _) = fa::wadd(m3hi, m3lo, r3, c);
+
+            (r2, c) = fa::wadd(m1hi, m1lo, r2, false);
+            (r3, _) = fa::wadd(0u64, 0u64, r3, c);
+
+            // return
+            (a.0).0 = [r2 as u64, (r2 >> 64) as u64, r3 as u64, (r3 >> 64) as u64];
         });
     } else if can_use_no_carry_mul_opt {
         // This modular multiplication algorithm uses Montgomery

--- a/ff-macros/src/montgomery/square.rs
+++ b/ff-macros/src/montgomery/square.rs
@@ -5,109 +5,250 @@ pub(super) fn square_in_place_impl(
     num_limbs: usize,
     modulus_limbs: &[u64],
     modulus_has_spare_bit: bool,
+    yd_opt: bool,
 ) -> proc_macro2::TokenStream {
     let mut body = proc_macro2::TokenStream::new();
     let mut default = proc_macro2::TokenStream::new();
-
     let modulus_0 = modulus_limbs[0];
-    let double_num_limbs = 2 * num_limbs;
-    default.extend(quote! {
-        let mut r = [0u64; #double_num_limbs];
-        let mut carry = 0;
-    });
-    for i in 0..(num_limbs - 1) {
-        for j in (i + 1)..num_limbs {
-            let idx = i + j;
-            default.extend(quote! {
-                r[#idx] = fa::mac_with_carry(r[#idx], (a.0).0[#i], (a.0).0[#j], &mut carry);
-            })
-        }
-        default.extend(quote! {
-            r[#num_limbs + #i] = carry;
-            carry = 0;
-        });
-    }
-    default.extend(quote! { r[#double_num_limbs - 1] = r[#double_num_limbs - 2] >> 63; });
-    for i in 2..(double_num_limbs - 1) {
-        let idx = double_num_limbs - i;
-        default.extend(quote! { r[#idx] = (r[#idx] << 1) | (r[#idx - 1] >> 63); });
-    }
-    default.extend(quote! { r[1] <<= 1; });
+    let modulus_1 = modulus_limbs[1];
+    let modulus_2 = modulus_limbs[2];
+    let modulus_3 = modulus_limbs[3];
 
-    for i in 0..num_limbs {
-        let idx = 2 * i;
-        default.extend(quote! {
-            r[#idx] = fa::mac_with_carry(r[#idx], (a.0).0[#i], (a.0).0[#i], &mut carry);
-            carry = fa::adc(&mut r[#idx + 1], 0, carry);
-        });
-    }
-    // Montgomery reduction
-    default.extend(quote! { let mut carry2 = 0; });
-    for i in 0..num_limbs {
-        default.extend(quote! {
-            let k = r[#i].wrapping_mul(Self::INV);
-            let mut carry = 0;
-            fa::mac_discard(r[#i], k, #modulus_0, &mut carry);
-        });
-        for (j, modulus_j) in modulus_limbs.iter().enumerate().take(num_limbs).skip(1) {
-            let idx = j + i;
-            default.extend(quote! {
-                r[#idx] = fa::mac_with_carry(r[#idx], k, #modulus_j, &mut carry);
-            });
-        }
-        default.extend(quote! { carry2 = fa::adc(&mut r[#num_limbs + #i], carry, carry2); });
-    }
-    default.extend(quote! { (a.0).0 = r[#num_limbs..].try_into().unwrap(); });
+    const U64_P: [u64; 4] = [
+        0x43e1f593f0000001,
+        0x2833e84879b97091,
+        0xb85045b68181585d,
+        0x30644e72e131a029,
+    ];
+    if yd_opt
+        && num_limbs == 4
+        && modulus_0 == U64_P[0]
+        && modulus_1 == U64_P[1]
+        && modulus_2 == U64_P[2]
+        && modulus_3 == U64_P[3]
+    {
+        body.extend(quote! {
+            let (c00hi, c00lo) = fa::mult((a.0).0[0], (a.0).0[0]);
+            let (c01hi, c01lo) = fa::mult((a.0).0[0], (a.0).0[1]);
+            let (c02hi, c02lo) = fa::mult((a.0).0[0], (a.0).0[2]);
+            let (c03hi, c03lo) = fa::mult((a.0).0[0], (a.0).0[3]);
+            let (c10hi, c10lo) = (c01hi, c01lo);
+            let (c11hi, c11lo) = fa::mult((a.0).0[1], (a.0).0[1]);
+            let (c12hi, c12lo) = fa::mult((a.0).0[1], (a.0).0[2]);
+            let (c13hi, c13lo) = fa::mult((a.0).0[1], (a.0).0[3]);
+            let (c20hi, c20lo) = (c02hi, c02lo);
+            let (c21hi, c21lo) = (c12hi, c12lo);
+            let (c22hi, c22lo) = fa::mult((a.0).0[2], (a.0).0[2]);
+            let (c23hi, c23lo) = fa::mult((a.0).0[2], (a.0).0[3]);
+            let (c30hi, c30lo) = (c03hi, c03lo);
+            let (c31hi, c31lo) = (c13hi, c13lo);
+            let (c32hi, c32lo) = (c23hi, c23lo);
+            let (c33hi, c33lo) = fa::mult((a.0).0[3], (a.0).0[3]);
 
-    if num_limbs == 1 {
-        // We default to multiplying with `a` using the `Mul` impl
-        // for the N == 1 case
-        quote!({
-            *a *= *a;
-        })
-    } else if (2..=6).contains(&num_limbs) && can_use_no_carry_mul_opt {
-        body.extend(quote!({
-            if cfg!(all(
-                feature = "asm",
-                target_feature = "bmi2",
-                target_feature = "adx",
-                target_arch = "x86_64"
-            )) {
-                #[cfg(
-                    all(
-                        feature = "asm",
-                        target_feature = "bmi2",
-                        target_feature = "adx",
-                        target_arch = "x86_64"
-                    )
-                )]
-                #[allow(unsafe_code, unused_mut)]
-                {
-                    ark_ff::x86_64_asm_square!(#num_limbs, (a.0).0);
-                }
-            } else {
-                #[cfg(
-                    not(all(
-                        feature = "asm",
-                        target_feature = "bmi2",
-                        target_feature = "adx",
-                        target_arch = "x86_64"
-                    ))
-                )]
-                {
-                    #default
-                }
-            }
-        }));
-        body.extend(quote!(__subtract_modulus(a);));
+            let mut c: bool;
+            let mut r0 = 0u128;
+            let mut r1 = 0u128;
+            let mut r2 = 0u128;
+            let mut r3 = 0u128;
+
+            (r0, _) = fa::wadd(c00hi, c00lo, r0, false);
+
+            (r0, c) = fa::wadd(c01lo, 0u64, r0, false);
+            (r1, _) = fa::wadd(c11hi, c11lo, r1, c);
+
+            (r0, c) = fa::wadd(c10lo, 0u64, r0, false);
+            (r1, c) = fa::wadd(c12lo, c01hi, r1, c);
+            (r2, _) = fa::wadd(0u64, c12hi, r2, c);
+
+            (r1, c) = fa::wadd(c21lo, c10hi, r1, false);
+            (r2, _) = fa::wadd(0u64, c21hi, r2, c);
+
+            (r1, c) = fa::wadd(c02hi, c02lo, r1, false);
+            (r2, c) = fa::wadd(c13hi, c13lo, r2, c); // ignore c - limited to input < p
+
+            (r1, c) = fa::wadd(c20hi, c20lo, r1, false);
+            (r2, c) = fa::wadd(c31hi, c31lo, r2, c); // ignore c - limited to input < p
+
+            (r1, c) = fa::wadd(c03lo, 0u64, r1, false);
+            (r2, c) = fa::wadd(c23lo, c03hi, r2, c);
+            (r3, _) = fa::wadd(0u64, c23hi, r3, c);
+
+            (r1, c) = fa::wadd(c30lo, 0u64, r1, false);
+            (r2, c) = fa::wadd(c32lo, c30hi, r2, c);
+            (r3, _) = fa::wadd(0u64, c32hi, r3, c);
+
+            const U64_I2: [u64; 4] = [
+                0x18ee753c76f9dc6f,
+                0x54ad7e14a329e70f,
+                0x2b16366f4f7684df,
+                0x133100d71fdf3579,
+            ];
+            let (r0hi, r0lo) = ((r0 >> 64) as u64, r0 as u64);
+            let (ir000hi, ir000lo) = fa::mult(r0lo, U64_I2[0]);
+            let (ir001hi, ir001lo) = fa::mult(r0lo, U64_I2[1]);
+            let (ir002hi, ir002lo) = fa::mult(r0lo, U64_I2[2]);
+            let (ir003hi, ir003lo) = fa::mult(r0lo, U64_I2[3]);
+            let (ir010hi, ir010lo) = fa::mult(r0hi, U64_I2[0]);
+            let (ir011hi, ir011lo) = fa::mult(r0hi, U64_I2[1]);
+            let (ir012hi, ir012lo) = fa::mult(r0hi, U64_I2[2]);
+            let (ir013hi, ir013lo) = fa::mult(r0hi, U64_I2[3]);
+
+            (r1, c) = fa::wadd(ir000hi, ir000lo, r1, false);
+            (r2, c) = fa::wadd(c22hi, c22lo, r2, c);
+            (r3, _) = fa::wadd(c33hi, c33lo, r3, c);
+
+            (r1, c) = fa::wadd(ir001lo, 0u64, r1, false);
+            (r2, c) = fa::wadd(ir002hi, ir002lo, r2, c);
+            (r3, _) = fa::wadd(0u64, ir003hi, r3, c);
+
+            (r1, c) = fa::wadd(ir010lo, 0u64, r1, false);
+            (r2, c) = fa::wadd(ir003lo, ir001hi, r2, c);
+            (r3, _) = fa::wadd(0u64, ir012hi, r3, c);
+
+            const U64_I1: [u64; 4] = [
+                0x2d3e8053e396ee4d,
+                0xca478dbeab3c92cd,
+                0xb2d8f06f77f52a93,
+                0x24d6ba07f7aa8f04,
+            ];
+            let r1lo = r1 as u64;
+            let (ir100hi, ir100lo) = fa::mult(r1lo, U64_I1[0]);
+            let (ir101hi, ir101lo) = fa::mult(r1lo, U64_I1[1]);
+            let (ir102hi, ir102lo) = fa::mult(r1lo, U64_I1[2]);
+            let (ir103hi, ir103lo) = fa::mult(r1lo, U64_I1[3]);
+
+            (r1, c) = fa::wadd(ir100lo, 0u64, r1, false);
+            (r2, c) = fa::wadd(ir012lo, ir010hi, r2, c);
+            (r3, _) = fa::wadd(ir013hi, ir013lo, r3, c);
+
+            let m = (Self::INV).wrapping_mul((r1 >> 64) as u64);
+            let (m0hi, m0lo) = fa::mult(m, #modulus_0);
+            let (m1hi, m1lo) = fa::mult(m, #modulus_1);
+            let (m2hi, m2lo) = fa::mult(m, #modulus_2);
+            let (m3hi, m3lo) = fa::mult(m, #modulus_3);
+
+            (_, c) = fa::wadd(m0lo, 0u64, r1, false);
+            (r2, c) = fa::wadd(ir011hi, ir011lo, r2, c);
+            (r3, _) = fa::wadd(0u64, ir102hi, r3, c);
+
+            (r2, c) = fa::wadd(ir102lo, ir100hi, r2, false);
+            (r3, _) = fa::wadd(ir103hi, ir103lo, r3, c);
+
+            (r2, c) = fa::wadd(ir101hi, ir101lo, r2, false);
+            (r3, _) = fa::wadd(0u64, m2hi, r3, c);
+
+            (r2, c) = fa::wadd(m2lo, m0hi, r2, false);
+            (r3, _) = fa::wadd(m3hi, m3lo, r3, c);
+
+            (r2, c) = fa::wadd(m1hi, m1lo, r2, false);
+            (r3, _) = fa::wadd(0u64, 0u64, r3, c);
+
+            // return
+            a.0.0 = [r2 as u64, (r2 >> 64) as u64, r3 as u64, (r3 >> 64) as u64]
+        });
         body
     } else {
-        body.extend(quote!( #default ));
-        if modulus_has_spare_bit {
-            body.extend(quote!(__subtract_modulus(a);));
-        } else {
-            body.extend(quote!(__subtract_modulus_with_carry(a, carry2 != 0);));
+        let modulus_0 = modulus_limbs[0];
+        let double_num_limbs = 2 * num_limbs;
+
+        default.extend(quote! {
+            let mut r = [0u64; #double_num_limbs];
+            let mut carry = 0;
+        });
+        for i in 0..(num_limbs - 1) {
+            for j in (i + 1)..num_limbs {
+                let idx = i + j;
+                default.extend(quote! {
+                    r[#idx] = fa::mac_with_carry(r[#idx], (a.0).0[#i], (a.0).0[#j], &mut carry);
+                })
+            }
+            default.extend(quote! {
+                r[#num_limbs + #i] = carry;
+                carry = 0;
+            });
         }
-        body
+        default.extend(quote! { r[#double_num_limbs - 1] = r[#double_num_limbs - 2] >> 63; });
+        for i in 2..(double_num_limbs - 1) {
+            let idx = double_num_limbs - i;
+            default.extend(quote! { r[#idx] = (r[#idx] << 1) | (r[#idx - 1] >> 63); });
+        }
+        default.extend(quote! { r[1] <<= 1; });
+
+        for i in 0..num_limbs {
+            let idx = 2 * i;
+            default.extend(quote! {
+                r[#idx] = fa::mac_with_carry(r[#idx], (a.0).0[#i], (a.0).0[#i], &mut carry);
+                carry = fa::adc(&mut r[#idx + 1], 0, carry);
+            });
+        }
+        // Montgomery reduction
+        default.extend(quote! { let mut carry2 = 0; });
+        for i in 0..num_limbs {
+            default.extend(quote! {
+                let k = r[#i].wrapping_mul(Self::INV);
+                let mut carry = 0;
+                fa::mac_discard(r[#i], k, #modulus_0, &mut carry);
+            });
+            for (j, modulus_j) in modulus_limbs.iter().enumerate().take(num_limbs).skip(1) {
+                let idx = j + i;
+                default.extend(quote! {
+                    r[#idx] = fa::mac_with_carry(r[#idx], k, #modulus_j, &mut carry);
+                });
+            }
+            default.extend(quote! { carry2 = fa::adc(&mut r[#num_limbs + #i], carry, carry2); });
+        }
+        default.extend(quote! { (a.0).0 = r[#num_limbs..].try_into().unwrap(); });
+
+        if num_limbs == 1 {
+            // We default to multiplying with `a` using the `Mul` impl
+            // for the N == 1 case
+            quote!({
+                *a *= *a;
+            })
+        } else if (2..=6).contains(&num_limbs) && can_use_no_carry_mul_opt {
+            body.extend(quote!({
+                if cfg!(all(
+                    feature = "asm",
+                    target_feature = "bmi2",
+                    target_feature = "adx",
+                    target_arch = "x86_64"
+                )) {
+                    #[cfg(
+                        all(
+                            feature = "asm",
+                            target_feature = "bmi2",
+                            target_feature = "adx",
+                            target_arch = "x86_64"
+                        )
+                    )]
+                    #[allow(unsafe_code, unused_mut)]
+                    {
+                        ark_ff::x86_64_asm_square!(#num_limbs, (a.0).0);
+                    }
+                } else {
+                    #[cfg(
+                        not(all(
+                            feature = "asm",
+                            target_feature = "bmi2",
+                            target_feature = "adx",
+                            target_arch = "x86_64"
+                        ))
+                    )]
+                    {
+                        #default
+                    }
+                }
+            }));
+            body.extend(quote!(__subtract_modulus(a);));
+            body
+        } else {
+            body.extend(quote!( #default ));
+            if modulus_has_spare_bit {
+                body.extend(quote!(__subtract_modulus(a);));
+            } else {
+                body.extend(quote!(__subtract_modulus_with_carry(a, carry2 != 0);));
+            }
+            body
+        }
     }
 }

--- a/ff/src/biginteger/arithmetic.rs
+++ b/ff/src/biginteger/arithmetic.rs
@@ -151,9 +151,6 @@ pub fn mac_with_carry(a: u64, b: u64, c: u64, carry: &mut u64) -> u64 {
 }
 
 // Some helpers from Yuvals codebase
-// I unrolled this -- as it gives performance optimisation
-// Technically, later there is a way to fully unroll this generically
-// with macros TODO
 #[inline(always)]
 pub fn addv(mut a: [u64; 5], b: [u64; 5]) -> [u64; 5] {
     let mut carry: u64;
@@ -225,7 +222,7 @@ pub fn ysub(a: [u64; 4], b: [u64; 4]) -> [u64; 4] {
 
     let tmp = a[3] as i128 - b[3] as i128 + borrow as i128;
     c[3] = tmp as u64;
-    borrow = tmp >> 64;
+    _ = tmp >> 64;
 
     c
 }
@@ -234,6 +231,19 @@ pub fn ysub(a: [u64; 4], b: [u64; 4]) -> [u64; 4] {
 pub fn carrying_mul_add(a: u64, b: u64, add: u64, carry: u64) -> (u64, u64) {
     let c: u128 = a as u128 * b as u128 + carry as u128 + add as u128;
     (c as u64, (c >> 64) as u64)
+}
+
+#[inline]
+pub const fn mult(lhs: u64, rhs: u64) -> (u64, u64) {
+    let res = (lhs as u128).wrapping_mul(rhs as u128);
+    ((res >> 64) as u64, res as u64)
+}
+
+#[inline]
+pub const fn wadd(lhs: u64, rhs: u64, acc: u128, c: bool) -> (u128, bool) {
+    let (reslo, c) = (acc as u64).carrying_add(rhs, c);
+    let (reshi, c) = ((acc >> 64) as u64).carrying_add(lhs, c);
+    ((reshi as u128) << 64 | reslo as u128, c)
 }
 
 /// Compute the NAF (non-adjacent form) of num

--- a/ff/src/biginteger/arithmetic.rs
+++ b/ff/src/biginteger/arithmetic.rs
@@ -150,6 +150,92 @@ pub fn mac_with_carry(a: u64, b: u64, c: u64, carry: &mut u64) -> u64 {
     tmp as u64
 }
 
+// Some helpers from Yuvals codebase
+// I unrolled this -- as it gives performance optimisation
+// Technically, later there is a way to fully unroll this generically
+// with macros TODO
+#[inline(always)]
+pub fn addv(mut a: [u64; 5], b: [u64; 5]) -> [u64; 5] {
+    let mut carry: u64;
+
+    // Limb 0
+    let sum0 = a[0] as u128 + b[0] as u128;
+    a[0] = sum0 as u64;
+    carry = (sum0 >> 64) as u64;
+
+    // Limb 1
+    let sum1 = a[1] as u128 + b[1] as u128 + carry as u128;
+    a[1] = sum1 as u64;
+    carry = (sum1 >> 64) as u64;
+
+    // Limb 2
+    let sum2 = a[2] as u128 + b[2] as u128 + carry as u128;
+    a[2] = sum2 as u64;
+    carry = (sum2 >> 64) as u64;
+
+    // Limb 3
+    let sum3 = a[3] as u128 + b[3] as u128 + carry as u128;
+    a[3] = sum3 as u64;
+    carry = (sum3 >> 64) as u64;
+
+    // Limb 4
+    let sum4 = a[4] as u128 + b[4] as u128 + carry as u128;
+    a[4] = sum4 as u64;
+    // final carry is discarded
+
+    a
+}
+
+#[inline(always)]
+pub fn reduce_ct(a: [u64; 4], two_p: [u64; 4]) -> [u64; 4] {
+    let b = [[0_u64; 4], two_p];
+    let msb = (a[3] >> 63) & 1;
+    ysub(a, b[msb as usize])
+}
+// This is just nameed as ysub for now : it should be sub
+//#[inline(always)]
+//pub fn ysub<const N: usize>(a: [u64; N], b: [u64; N]) -> [u64; N] {
+//    let mut borrow: i128 = 0;
+//    let mut c = [0; N];
+//    for i in 0..N {
+//        let tmp = a[i] as i128 - b[i] as i128 + borrow as i128;
+//        c[i] = tmp as u64;
+//        borrow = tmp >> 64
+//    }
+//    c
+//}
+
+// Once again unrolled to potentially speed things
+#[inline(always)]
+pub fn ysub(a: [u64; 4], b: [u64; 4]) -> [u64; 4] {
+    let mut borrow: i128 = 0;
+    let mut c = [0; 4];
+
+    let tmp = a[0] as i128 - b[0] as i128 + borrow as i128;
+    c[0] = tmp as u64;
+    borrow = tmp >> 64;
+
+    let tmp = a[1] as i128 - b[1] as i128 + borrow as i128;
+    c[1] = tmp as u64;
+    borrow = tmp >> 64;
+
+    let tmp = a[2] as i128 - b[2] as i128 + borrow as i128;
+    c[2] = tmp as u64;
+    borrow = tmp >> 64;
+
+    let tmp = a[3] as i128 - b[3] as i128 + borrow as i128;
+    c[3] = tmp as u64;
+    borrow = tmp >> 64;
+
+    c
+}
+
+#[inline(always)]
+pub fn carrying_mul_add(a: u64, b: u64, add: u64, carry: u64) -> (u64, u64) {
+    let c: u128 = a as u128 * b as u128 + carry as u128 + add as u128;
+    (c as u64, (c >> 64) as u64)
+}
+
 /// Compute the NAF (non-adjacent form) of num
 pub fn find_naf(num: &[u64]) -> Vec<i8> {
     let is_zero = |num: &[u64]| num.iter().all(|x| *x == 0u64);

--- a/ff/src/fields/models/fp/montgomery_backend.rs
+++ b/ff/src/fields/models/fp/montgomery_backend.rs
@@ -58,6 +58,9 @@ pub trait MontConfig<const N: usize>: 'static + Sync + Send + Sized {
     #[doc(hidden)]
     const MODULUS_HAS_SPARE_BIT: bool = modulus_has_spare_bit::<Self, N>();
 
+    /// Should we use YD's optimisation?
+    const YD_OPT: bool;
+
     /// 2^s root of unity computed by GENERATOR^t
     const TWO_ADIC_ROOT_OF_UNITY: Fp<MontBackend<Self, N>, N>;
 
@@ -159,9 +162,10 @@ pub trait MontConfig<const N: usize>: 'static + Sync + Send + Sized {
     const BARRETT_MU: u64 = {
         // Compute Barrett mu = floor(2^(modulus_bits + 63) / modulus)
         assert!(Self::MODULUS.num_spare_bits() < 64);
-        let r_times_r_prime_over_2 =
-            crate::const_helpers::RBuffer::<N>([0u64; N],
-                1 << (63 - Self::MODULUS.num_spare_bits()));
+        let r_times_r_prime_over_2 = crate::const_helpers::RBuffer::<N>(
+            [0u64; N],
+            1 << (63 - Self::MODULUS.num_spare_bits()),
+        );
         // Use const_quotient! to compute the quotient
         let result: BigInt<N> = const_quotient!(r_times_r_prime_over_2, &Self::MODULUS);
         // Result should be a u64
@@ -915,7 +919,7 @@ impl<T: MontConfig<N>, const N: usize> Fp<MontBackend<T, N>, N> {
     pub fn mul_u64(self, other: u64) -> Self {
         // Stage 1: Bignum Multiplication
         // Compute c = self.0 * other. Result c has N+1 limbs.
-        let c = bigint_mul_by_u64(&self.0.0, other);
+        let c = bigint_mul_by_u64(&self.0 .0, other);
 
         // Stage 2: Barrett Reduction
         let r = barrett_reduce_nplus1_to_n::<T, N>(c);
@@ -1140,12 +1144,12 @@ fn sub_bigint_plus_one_prime<const N: usize>(
     // This loop covers indices i = 1 to N-1.
     // It uses a_hi_n limbs from index 0 to N-2.
     for i in 1..N {
-        result_lo_n[i] = a_hi_n[i-1]; // Initialize result limb with corresponding a limb
+        result_lo_n[i] = a_hi_n[i - 1]; // Initialize result limb with corresponding a limb
         borrow = fa::sbb(&mut result_lo_n[i], b_lo_n[i], borrow); // result_lo_n[i] -= b_lo_n[i] + borrow
     }
 
     // Subtract high limb: result_hi = a_hi_n[N-1] - b_hi - borrow
-    let mut result_hi = a_hi_n[N-1]; // Initialize result limb with last a limb
+    let mut result_hi = a_hi_n[N - 1]; // Initialize result limb with last a limb
     borrow = fa::sbb(&mut result_hi, b_hi, borrow); // result_hi -= b_hi + borrow
 
     let final_borrow_occurred = borrow != 0;
@@ -1228,7 +1232,9 @@ fn bigint_mul_by_u128<const N: usize>(val: &BigInt<N>, other: u128) -> ([u64; 2]
 /// Old conditional subtraction logic for Barrett reduction
 /// Takes an N+1 limb intermediate result `r_tmp` and returns the N-limb final result.
 #[inline(always)]
-fn _barrett_cond_subtract_old<T: MontConfig<N>, const N: usize>(r_tmp: ([u64; N], u64)) -> [u64; N] {
+fn _barrett_cond_subtract_old<T: MontConfig<N>, const N: usize>(
+    r_tmp: ([u64; N], u64),
+) -> [u64; N] {
     let mut current_r = r_tmp; // Working variable in ([u64; N], u64) format
 
     if T::MODULUS_NUM_SPARE_BITS >= 1 {
@@ -1236,11 +1242,17 @@ fn _barrett_cond_subtract_old<T: MontConfig<N>, const N: usize>(r_tmp: ([u64; N]
         if T::MODULUS_NUM_SPARE_BITS >= 2 {
             // Optimization for S >= 2: r_tmp = c - m*2p < 4p
             // High limb of current_r should initially be 0
-            debug_assert!(current_r.1 == 0, "High limb of r_tmp should be zero when S >= 2");
+            debug_assert!(
+                current_r.1 == 0,
+                "High limb of r_tmp should be zero when S >= 2"
+            );
 
             // Conditional subtraction 1 (if r >= 2P) using N+1 compare/sub
-            if compare_bigint_plus_one(current_r, T::MODULUS_TIMES_2_NPLUS1) != core::cmp::Ordering::Less {
-                let (sub_res, sub_borrow) = sub_bigint_plus_one(current_r, T::MODULUS_TIMES_2_NPLUS1);
+            if compare_bigint_plus_one(current_r, T::MODULUS_TIMES_2_NPLUS1)
+                != core::cmp::Ordering::Less
+            {
+                let (sub_res, sub_borrow) =
+                    sub_bigint_plus_one(current_r, T::MODULUS_TIMES_2_NPLUS1);
                 debug_assert!(!sub_borrow, "Borrow should not occur subtracting 2P (S>=2)");
                 current_r = sub_res;
             }
@@ -1251,26 +1263,42 @@ fn _barrett_cond_subtract_old<T: MontConfig<N>, const N: usize>(r_tmp: ([u64; N]
                 current_r = sub_res;
             }
             // Result must fit in N limbs now
-            debug_assert!(current_r.1 == 0, "High limb must be zero after final subtraction (S>=2)");
+            debug_assert!(
+                current_r.1 == 0,
+                "High limb must be zero after final subtraction (S>=2)"
+            );
             current_r.0 // Return N low limbs
         } else {
             // Case S == 1: r_tmp = c - m*2p might temporarily exceed N limbs initially
 
             // Conditional subtraction 1: if r >= 2p
-            if compare_bigint_plus_one(current_r, T::MODULUS_TIMES_2_NPLUS1) != core::cmp::Ordering::Less {
+            if compare_bigint_plus_one(current_r, T::MODULUS_TIMES_2_NPLUS1)
+                != core::cmp::Ordering::Less
+            {
                 // Subtract 2P using N+1 limb subtraction
-                let (sub_res, sub_borrow) = sub_bigint_plus_one(current_r, T::MODULUS_TIMES_2_NPLUS1);
+                let (sub_res, sub_borrow) =
+                    sub_bigint_plus_one(current_r, T::MODULUS_TIMES_2_NPLUS1);
                 // After subtracting 2P, the result MUST fit in N limbs
-                debug_assert!(sub_res.1 == 0, "High limb must be 0 after 2P subtraction when S=1");
-                debug_assert!(!sub_borrow, "Borrow should not occur when subtracting 2P for S=1");
+                debug_assert!(
+                    sub_res.1 == 0,
+                    "High limb must be 0 after 2P subtraction when S=1"
+                );
+                debug_assert!(
+                    !sub_borrow,
+                    "Borrow should not occur when subtracting 2P for S=1"
+                );
                 current_r = sub_res; // Update current_r (now guaranteed to have high limb 0)
             }
             // At this point, current_r < 2P and its high limb is 0.
-            debug_assert!(current_r.1 == 0, "High limb should be 0 before N-limb subtraction (S=1)");
+            debug_assert!(
+                current_r.1 == 0,
+                "High limb should be 0 before N-limb subtraction (S=1)"
+            );
             let mut r_n_limbs = BigInt::<N>(current_r.0); // Extract N low limbs
 
             // Conditional subtraction 2 (if r >= P) using N limbs directly
-            if r_n_limbs >= T::MODULUS { // Compare N limbs
+            if r_n_limbs >= T::MODULUS {
+                // Compare N limbs
                 r_n_limbs.sub_with_borrow(&T::MODULUS); // Subtract N limbs. Ignore borrow.
             }
             r_n_limbs.0 // Return N low limbs
@@ -1279,7 +1307,9 @@ fn _barrett_cond_subtract_old<T: MontConfig<N>, const N: usize>(r_tmp: ([u64; N]
         // Case S == 0: Use (N+1)-limb helpers throughout
 
         // Conditional subtraction 1: if r >= 2p
-        if compare_bigint_plus_one(current_r, T::MODULUS_TIMES_2_NPLUS1) != core::cmp::Ordering::Less {
+        if compare_bigint_plus_one(current_r, T::MODULUS_TIMES_2_NPLUS1)
+            != core::cmp::Ordering::Less
+        {
             let (sub_res, sub_borrow) = sub_bigint_plus_one(current_r, T::MODULUS_TIMES_2_NPLUS1);
             debug_assert!(!sub_borrow, "Borrow should not occur subtracting 2P (S=0)");
             current_r = sub_res;
@@ -1287,15 +1317,25 @@ fn _barrett_cond_subtract_old<T: MontConfig<N>, const N: usize>(r_tmp: ([u64; N]
         // Now current_r = c mod 2p, represented as ([u64; N], u64)
 
         // Conditional subtraction 2: if r >= p
-        if compare_bigint_plus_one(current_r, T::MODULUS_NPLUS1) != core::cmp::Ordering::Less { // if r >= p
-                let (sub_res, sub_borrow) = sub_bigint_plus_one(current_r, T::MODULUS_NPLUS1);
-                // Result MUST fit in N limbs now
-                debug_assert!(sub_res.1 == 0, "High limb must be zero after subtracting P (S=0)");
-                debug_assert!(!sub_borrow, "Borrow should not occur when subtracting P for S=0");
-                current_r = sub_res;
+        if compare_bigint_plus_one(current_r, T::MODULUS_NPLUS1) != core::cmp::Ordering::Less {
+            // if r >= p
+            let (sub_res, sub_borrow) = sub_bigint_plus_one(current_r, T::MODULUS_NPLUS1);
+            // Result MUST fit in N limbs now
+            debug_assert!(
+                sub_res.1 == 0,
+                "High limb must be zero after subtracting P (S=0)"
+            );
+            debug_assert!(
+                !sub_borrow,
+                "Borrow should not occur when subtracting P for S=0"
+            );
+            current_r = sub_res;
         }
         // At this point, current_r < P and its high limb must be 0.
-        debug_assert!(current_r.1 == 0, "High limb must be zero after final subtraction (S=0)");
+        debug_assert!(
+            current_r.1 == 0,
+            "High limb must be zero after final subtraction (S=0)"
+        );
         current_r.0 // Return N low limbs
     }
 }
@@ -1317,61 +1357,85 @@ fn barrett_cond_subtract<T: MontConfig<N>, const N: usize>(r_tmp: ([u64; N], u64
     } else {
         // S >= 1: 2p fits N limbs (mostly). Compare N limbs.
         // We assume r_tmp's high limb is 0 here if S >= 1.
-        debug_assert!(r_hi == 0, "High limb expected to be 0 if S >= 1 before 2p comparison");
+        debug_assert!(
+            r_hi == 0,
+            "High limb expected to be 0 if S >= 1 before 2p comparison"
+        );
         let p2_n = BigInt::<N>(T::MODULUS_TIMES_2_NPLUS1.0);
         r_n.cmp(&p2_n)
     };
 
-    if compare_2p != core::cmp::Ordering::Less { // r_tmp >= 2p
+    if compare_2p != core::cmp::Ordering::Less {
+        // r_tmp >= 2p
         // Compare with 3p
         let compare_3p = if T::MODULUS_NUM_SPARE_BITS < 2 {
-             // S < 2 (S=0 or S=1): Need N+1 compare
+            // S < 2 (S=0 or S=1): Need N+1 compare
             compare_bigint_plus_one(r_tmp, T::MODULUS_TIMES_3_NPLUS1)
         } else {
             // S >= 2: 3p fits N limbs. Compare N limbs.
-            debug_assert!(r_hi == 0, "High limb expected to be 0 if S >= 2 before 3p comparison");
+            debug_assert!(
+                r_hi == 0,
+                "High limb expected to be 0 if S >= 2 before 3p comparison"
+            );
             let p3_n = BigInt::<N>(T::MODULUS_TIMES_3_NPLUS1.0);
             r_n.cmp(&p3_n)
         };
 
-        if compare_3p != core::cmp::Ordering::Less { // r_tmp >= 3p
+        if compare_3p != core::cmp::Ordering::Less {
+            // r_tmp >= 3p
             // Subtract 3p
             if T::MODULUS_NUM_SPARE_BITS >= 2 {
                 // S >= 2: 3p fits N limbs. Use N-limb sub.
-                debug_assert!(r_hi == 0, "High limb expected to be 0 if S >= 2 for 3p subtraction");
+                debug_assert!(
+                    r_hi == 0,
+                    "High limb expected to be 0 if S >= 2 for 3p subtraction"
+                );
                 let p3_n = BigInt::<N>(T::MODULUS_TIMES_3_NPLUS1.0);
                 let (res_n, borrow_n) = r_n.const_sub_with_borrow(&p3_n);
                 debug_assert!(!borrow_n, "Borrow should not occur subtracting 3p (S>=2)");
                 final_limbs = res_n.0;
             } else {
                 // S < 2: Use N+1 limb sub.
-                let ((res_n_limbs, res_hi_limb), borrow_n1) = sub_bigint_plus_one(r_tmp, T::MODULUS_TIMES_3_NPLUS1);
+                let ((res_n_limbs, res_hi_limb), borrow_n1) =
+                    sub_bigint_plus_one(r_tmp, T::MODULUS_TIMES_3_NPLUS1);
                 debug_assert!(!borrow_n1, "Borrow should not occur subtracting 3p (S<2)");
-                debug_assert!(res_hi_limb == 0, "High limb must be zero after subtracting 3p");
+                debug_assert!(
+                    res_hi_limb == 0,
+                    "High limb must be zero after subtracting 3p"
+                );
                 final_limbs = res_n_limbs;
             }
-        } else { // 2p <= r_tmp < 3p
+        } else {
+            // 2p <= r_tmp < 3p
             // Subtract 2p
             if T::MODULUS_NUM_SPARE_BITS >= 1 {
                 // S >= 1: 2p fits N limbs (mostly). Use N-limb sub.
-                debug_assert!(r_hi == 0, "High limb expected to be 0 if S >= 1 for 2p subtraction");
+                debug_assert!(
+                    r_hi == 0,
+                    "High limb expected to be 0 if S >= 1 for 2p subtraction"
+                );
                 let p2_n = BigInt::<N>(T::MODULUS_TIMES_2_NPLUS1.0);
                 let (res_n, borrow_n) = r_n.const_sub_with_borrow(&p2_n);
                 debug_assert!(!borrow_n, "Borrow should not occur subtracting 2p (S>=1)");
                 final_limbs = res_n.0;
             } else {
                 // S == 0: Use N+1 limb sub.
-                let ((res_n_limbs, res_hi_limb), borrow_n1) = sub_bigint_plus_one(r_tmp, T::MODULUS_TIMES_2_NPLUS1);
+                let ((res_n_limbs, res_hi_limb), borrow_n1) =
+                    sub_bigint_plus_one(r_tmp, T::MODULUS_TIMES_2_NPLUS1);
                 debug_assert!(!borrow_n1, "Borrow should not occur subtracting 2p (S=0)");
-                debug_assert!(res_hi_limb == 0, "High limb must be zero after subtracting 2p");
+                debug_assert!(
+                    res_hi_limb == 0,
+                    "High limb must be zero after subtracting 2p"
+                );
                 final_limbs = res_n_limbs;
             }
         }
-    } else { // r_tmp < 2p
+    } else {
+        // r_tmp < 2p
         // Compare with p
         let compare_p = if T::MODULUS_NUM_SPARE_BITS >= 1 {
             // S >= 1: Use N-limb compare.
-             // Assume r_tmp high limb is 0 because r_tmp < 2p and 2p fits N limbs (mostly) if S >= 1
+            // Assume r_tmp high limb is 0 because r_tmp < 2p and 2p fits N limbs (mostly) if S >= 1
             debug_assert!(r_hi == 0, "High limb expected to be 0 if S >= 1 and r < 2p");
             r_n.cmp(&T::MODULUS) // Compare N limbs
         } else {
@@ -1379,22 +1443,31 @@ fn barrett_cond_subtract<T: MontConfig<N>, const N: usize>(r_tmp: ([u64; N], u64
             compare_bigint_plus_one(r_tmp, T::MODULUS_NPLUS1)
         };
 
-        if compare_p != core::cmp::Ordering::Less { // p <= r_tmp < 2p
+        if compare_p != core::cmp::Ordering::Less {
+            // p <= r_tmp < 2p
             // Subtract p
             if T::MODULUS_NUM_SPARE_BITS >= 1 {
                 // S >= 1: Use N-limb sub.
-                debug_assert!(r_hi == 0, "High limb expected to be 0 if S >= 1 for p subtraction");
+                debug_assert!(
+                    r_hi == 0,
+                    "High limb expected to be 0 if S >= 1 for p subtraction"
+                );
                 let (res_n, borrow_n) = r_n.const_sub_with_borrow(&T::MODULUS);
                 debug_assert!(!borrow_n, "Borrow should not occur subtracting p (S>=1)");
                 final_limbs = res_n.0;
             } else {
                 // S == 0: Use N+1 limb sub.
-                 let ((res_n_limbs, res_hi_limb), borrow_n1) = sub_bigint_plus_one(r_tmp, T::MODULUS_NPLUS1);
-                 debug_assert!(!borrow_n1, "Borrow should not occur subtracting p (S=0)");
-                 debug_assert!(res_hi_limb == 0, "High limb must be zero after subtracting p");
+                let ((res_n_limbs, res_hi_limb), borrow_n1) =
+                    sub_bigint_plus_one(r_tmp, T::MODULUS_NPLUS1);
+                debug_assert!(!borrow_n1, "Borrow should not occur subtracting p (S=0)");
+                debug_assert!(
+                    res_hi_limb == 0,
+                    "High limb must be zero after subtracting p"
+                );
                 final_limbs = res_n_limbs;
             }
-        } else { // r_tmp < p
+        } else {
+            // r_tmp < p
             // Subtract 0 (No-op)
             // Result must already fit in N limbs. Assert high limb is 0.
             debug_assert!(r_hi == 0, "High limb must be zero when r_tmp < p");
@@ -1418,11 +1491,12 @@ fn barrett_reduce_nplus1_to_n<T: MontConfig<N>, const N: usize>(c: (u64, [u64; N
     // The highest limb is c_hi[N-1]. The second highest is c_hi[N-2].
     // Assume that `N >= 1`
     let tilde_c: u64 = if T::MODULUS_HAS_SPARE_BIT {
-        let high_limb = c_hi[N-1];
-        let second_high_limb = if N > 1 { c_hi[N-2] } else { c_lo }; // Use c_lo if N=1
-        (high_limb << T::MODULUS_NUM_SPARE_BITS) + (second_high_limb >> (64 - T::MODULUS_NUM_SPARE_BITS))
+        let high_limb = c_hi[N - 1];
+        let second_high_limb = if N > 1 { c_hi[N - 2] } else { c_lo }; // Use c_lo if N=1
+        (high_limb << T::MODULUS_NUM_SPARE_BITS)
+            + (second_high_limb >> (64 - T::MODULUS_NUM_SPARE_BITS))
     } else {
-        c_hi[N-1] // If no spare bits, tilde_c is just the highest limb
+        c_hi[N - 1] // If no spare bits, tilde_c is just the highest limb
     };
 
     // Estimate m = floor( (tilde_c * BARRETT_MU) / r )
@@ -1430,10 +1504,7 @@ fn barrett_reduce_nplus1_to_n<T: MontConfig<N>, const N: usize>(c: (u64, [u64; N
     let m: u64 = ((tilde_c as u128 * T::BARRETT_MU as u128) >> 64) as u64;
 
     // Compute m * 2p (N+1 limbs)
-    let (m_times_2p, m2p_overflow) = bigint_plus_one_mul_by_u64::<N>(
-        T::MODULUS_TIMES_2_NPLUS1,
-        m,
-    );
+    let (m_times_2p, m2p_overflow) = bigint_plus_one_mul_by_u64::<N>(T::MODULUS_TIMES_2_NPLUS1, m);
     // If m * 2p overflows N+1 limbs, the logic might be flawed or input c was too large.
     debug_assert!(!m2p_overflow, "Overflow calculating m * 2p");
 
@@ -1448,11 +1519,11 @@ fn barrett_reduce_nplus1_to_n<T: MontConfig<N>, const N: usize>(c: (u64, [u64; N
 
 #[cfg(test)]
 mod test {
-    use ark_std::{str::FromStr, vec::*, UniformRand, test_rng};
+    use ark_std::{str::FromStr, test_rng, vec::*, UniformRand};
+    use ark_test_curves::ark_ff::BigInt as ArkBigInt;
     use ark_test_curves::bn254::Fr;
     use num_bigint::{BigInt, BigUint, Sign};
     use rand::Rng;
-    use ark_test_curves::ark_ff::BigInt as ArkBigInt;
 
     #[test]
     fn test_mul_u64_random() {
@@ -1460,14 +1531,14 @@ mod test {
         for _ in 0..100 {
             let a = Fr::rand(&mut rng);
             let b_val: u64 = rng.gen();
-            
+
             // Expected result using standard field multiplication
             let b_bigint = ArkBigInt::from(b_val);
             let expected_c = a * Fr::from(b_bigint);
-            
+
             // Actual result using the function under test
             let result_c = a.mul_u64(b_val);
-            
+
             assert_eq!(
                 result_c,
                 expected_c,
@@ -1497,8 +1568,7 @@ mod test {
             let result_c = a.mul_i64(b_val);
 
             assert_eq!(
-                result_c,
-                expected_c,
+                result_c, expected_c,
                 "mul_i64 failed: a = {}, b = {}\nGot:      {}\nExpected: {}",
                 a, b_val, result_c, expected_c
             );
@@ -1520,8 +1590,7 @@ mod test {
             let result_c = a.mul_u128(b_val);
 
             assert_eq!(
-                result_c,
-                expected_c,
+                result_c, expected_c,
                 "mul_u128 failed: a = {}, b = {}\nGot:      {}\nExpected: {}",
                 a, b_val, result_c, expected_c
             );
@@ -1534,7 +1603,7 @@ mod test {
         for _ in 0..100 {
             let a = Fr::rand(&mut rng);
             // Avoid i128::MIN as negation overflows
-            let b_val: i128 = rng.gen_range(i128::MIN + 1 ..= i128::MAX);
+            let b_val: i128 = rng.gen_range(i128::MIN + 1..=i128::MAX);
 
             // Expected result using standard field multiplication
             let expected_c = if b_val >= 0 {
@@ -1549,8 +1618,7 @@ mod test {
             let result_c = a.mul_i128(b_val);
 
             assert_eq!(
-                result_c,
-                expected_c,
+                result_c, expected_c,
                 "mul_i128 failed: a = {}, b = {}\nGot:      {}\nExpected: {}",
                 a, b_val, result_c, expected_c
             );

--- a/ff/src/lib.rs
+++ b/ff/src/lib.rs
@@ -6,6 +6,7 @@
     rust_2018_idioms,
     rust_2021_compatibility
 )]
+#![feature(bigint_helper_methods)]
 #![allow(clippy::op_ref, clippy::suspicious_op_assign_impl)]
 #![deny(unsafe_code)]
 #![doc = include_str!("../README.md")]


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Added Yuval Domb's Montgomerry multiplication algorithm into the A16z fork of Arkworks. 
The implemented code was based on their [current implementation of scalar_mul](https://github.com/worldfnd/ProveKit/blob/dd8134ec3f2ad4991caa87653254ee64daf2d441/block-multiplier/src/lib.rs#L121). I further optimised their helper functions by unrolling the for loops wherever possible. 
The current implementation specifically targets the bn_254 curve.
See [this repository](https://github.com/abiswas3/Montgomery-Benchmarks/blob/main/src/main.rs#L25) for how to use the new multiplication algorithm.
Note: The new codepath will only run if number of limbs = 4, and the modulus is the one used for the BN_254 curve -- specifically these [modulus_limbs](https://github.com/worldfnd/ProveKit/blob/dd8134ec3f2ad4991caa87653254ee64daf2d441/block-multiplier/src/constants.rs#L3) 


---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
