### PR TITLE
fix(ark-ff): make allocative an optional dependency

### DIFF
--- a/ff/Cargo.toml
+++ b/ff/Cargo.toml
@@ -29,7 +29,7 @@ zeroize = { workspace = true, features = ["zeroize_derive"] }
 num-bigint.workspace = true
 digest = { workspace = true, features = ["alloc"] }
 itertools.workspace = true
-allocative = "0.3.4"
+allocative = { version = "0.3.4", optional = true }
 
 [dev-dependencies]
 ark-test-curves = { workspace = true, features = [


### PR DESCRIPTION
This fixes an issue where `allocative` was always pulled into the dependency tree even when using `default-features = false`. This caused problems for no_std targets (e.g., RISC-V guest builds) where allocative requires std.

By making allocative optional, downstream crates can avoid pulling it in unless explicitly needed.

## Changes
- `ff/Cargo.toml`: Changed `allocative = "0.3.4"` to `allocative = { version = "0.3.4", optional = true }`