### PR TITLE
Gate allocative behind default

### DIFF
--- a/ec/src/models/short_weierstrass/affine.rs
+++ b/ec/src/models/short_weierstrass/affine.rs
@@ -271,7 +271,6 @@ impl<P: SWCurveConfig> AffineRepr for Affine<P> {
 
     /// Multiplies this element by the cofactor and output the
     /// resulting projective element.
-    #[must_use]
     fn mul_by_cofactor_to_group(&self) -> Self::Group {
         P::mul_affine(self, Self::Config::COFACTOR)
     }

--- a/ec/src/models/twisted_edwards/affine.rs
+++ b/ec/src/models/twisted_edwards/affine.rs
@@ -184,7 +184,6 @@ impl<P: TECurveConfig> AffineRepr for Affine<P> {
 
     /// Multiplies this element by the cofactor and output the
     /// resulting projective element.
-    #[must_use]
     fn mul_by_cofactor_to_group(&self) -> Self::Group {
         P::mul_affine(self, Self::Config::COFACTOR)
     }

--- a/ff/Cargo.toml
+++ b/ff/Cargo.toml
@@ -29,7 +29,7 @@ zeroize = { workspace = true, features = ["zeroize_derive"] }
 num-bigint.workspace = true
 digest = { workspace = true, features = ["alloc"] }
 itertools.workspace = true
-allocative = "0.3.4"
+allocative = { version = "0.3.4", optional = true }
 
 [dev-dependencies]
 ark-test-curves = { workspace = true, features = [
@@ -49,7 +49,7 @@ hex.workspace = true
 rand = "0.8"
 
 [features]
-default = []
+default = ["allocative"]
 std = ["ark-std/std", "ark-serialize/std", "itertools/use_std"]
 parallel = ["std", "rayon", "ark-std/parallel", "ark-serialize/parallel"]
 asm = []

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -2,7 +2,10 @@ use crate::{
     bits::{BitIteratorBE, BitIteratorLE},
     const_for, UniformRand,
 };
+
+#[cfg(feature = "default")]
 use allocative::Allocative;
+
 #[allow(unused)]
 use ark_ff_macros::unroll_for_loops;
 use ark_serialize::{
@@ -37,7 +40,8 @@ pub use signed::{SignedBigInt, S128, S192, S256, S64};
 pub mod signed_hi_32;
 pub use signed_hi_32::{SignedBigIntHi32, S160, S224, S96};
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Zeroize, Allocative)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Zeroize)]
+#[cfg_attr(feature = "default", derive(Allocative))]
 pub struct BigInt<const N: usize>(pub [u64; N]);
 
 impl<const N: usize> Default for BigInt<N> {

--- a/ff/src/biginteger/signed.rs
+++ b/ff/src/biginteger/signed.rs
@@ -1,5 +1,8 @@
 use crate::biginteger::{BigInt, BigInteger};
+
+#[cfg(feature = "default")]
 use allocative::Allocative;
+
 use ark_serialize::{
     CanonicalDeserialize, CanonicalSerialize, Compress, Read, SerializationError, Valid, Validate,
     Write,
@@ -15,7 +18,8 @@ use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 ///   Structural equality distinguishes `+0` and `-0` (since the sign bit differs).
 /// - Ordering treats `+0` and `-0` as equal: comparisons return `Ordering::Equal` when
 ///   both magnitudes are zero regardless of sign.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Allocative)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "default", derive(Allocative))]
 pub struct SignedBigInt<const N: usize> {
     pub magnitude: BigInt<N>,
     pub is_positive: bool,

--- a/ff/src/biginteger/signed_hi_32.rs
+++ b/ff/src/biginteger/signed_hi_32.rs
@@ -1,5 +1,8 @@
 use crate::biginteger::{BigInt, SignedBigInt, S128, S64};
+
+#[cfg(feature = "default")]
 use allocative::Allocative;
+
 use ark_serialize::{
     CanonicalDeserialize, CanonicalSerialize, Compress, Read, SerializationError, Valid, Validate,
     Write,
@@ -25,7 +28,8 @@ use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 /// - Zero is not normalized: a zero magnitude can be positive or negative. Structural equality
 ///   distinguishes `+0` and `-0`, but ordering treats them as equal.
 /// - Specialized fast paths exist for `N ∈ {0,1,2}`; larger `N` uses a generic path.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Allocative)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "default", derive(Allocative))]
 pub struct SignedBigIntHi32<const N: usize> {
     /// Little-endian low limbs: limb 0 = low 64 bits, limb 1 = next 64 bits, and so on
     magnitude_lo: [u64; N],

--- a/ff/src/fields/models/fp/mod.rs
+++ b/ff/src/fields/models/fp/mod.rs
@@ -2,7 +2,10 @@ use crate::{
     AdditiveGroup, BigInt, BigInteger, FftField, Field, LegendreSymbol, One, PrimeField,
     SqrtPrecomputation, Zero,
 };
+
+#[cfg(feature = "default")]
 use allocative::Allocative;
+
 use ark_serialize::{
     buffer_byte_size, CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
     CanonicalSerializeWithFlags, Compress, EmptyFlags, Flags, SerializationError, Valid, Validate,
@@ -124,6 +127,7 @@ pub struct Fp<P: FpConfig<N>, const N: usize>(
     #[doc(hidden)] pub PhantomData<P>,
 );
 
+#[cfg(feature = "default")]
 impl<P: FpConfig<N>, const N: usize> Allocative for Fp<P, N> {
     fn visit<'a, 'b: 'a>(&self, _visitor: &'a mut allocative::Visitor<'b>) {}
 }
@@ -706,7 +710,6 @@ impl<P: FpConfig<N>, const N: usize> Display for Fp<P, N> {
 impl<P: FpConfig<N>, const N: usize> Neg for Fp<P, N> {
     type Output = Self;
     #[inline]
-    #[must_use]
     fn neg(mut self) -> Self {
         P::neg_in_place(&mut self);
         self


### PR DESCRIPTION
Allocative needs to be behind the `default` feature for jolt inlines that use this repo. This gates the remaining instances of it behind default.

This also fixes two warnings that occur when using this branch in the secp256k1 inline.